### PR TITLE
Remove default config fallback in calibration job

### DIFF
--- a/audience/src/main/scala/com/thetradedesk/audience/utils/MapConfigReader.scala
+++ b/audience/src/main/scala/com/thetradedesk/audience/utils/MapConfigReader.scala
@@ -1,0 +1,98 @@
+package com.thetradedesk.audience.utils
+
+import java.time.LocalDate
+import scala.collection.mutable.ListBuffer
+import scala.util.Try
+import scala.reflect.runtime.universe._
+import scala.reflect.ClassTag
+
+/** Utility for reading configuration from a Map[String,String].
+  * Collects errors for missing or malformed values so callers can
+  * report all issues at once.
+  */
+class MapConfigReader(map: Map[String, String]) {
+  private val errors = ListBuffer.empty[String]
+
+  def getString(key: String): Option[String] = map.get(key) match {
+    case Some(v) => Some(v)
+    case None =>
+      errors += s"$key does not exist"
+      None
+  }
+
+  def getInt(key: String): Option[Int] = map.get(key) match {
+    case Some(v) =>
+      Try(v.toInt).toOption match {
+        case Some(i) => Some(i)
+        case None =>
+          errors += s"$key is expecting Int type"
+          None
+      }
+    case None =>
+      errors += s"$key does not exist"
+      None
+  }
+
+  def getDate(key: String): Option[LocalDate] = map.get(key) match {
+    case Some(v) =>
+      Try(LocalDate.parse(v)).toOption match {
+        case Some(d) => Some(d)
+        case None =>
+          errors += s"$key is expecting ISO date"
+          None
+      }
+    case None =>
+      errors += s"$key does not exist"
+      None
+  }
+
+  /** Print any collected errors and throw IllegalArgumentException if present. */
+  def assertValid(): Unit = {
+    if (errors.nonEmpty) {
+      println("Invalid config values:")
+      errors.foreach(e => println(s"- $e"))
+      throw new IllegalArgumentException("Invalid configuration")
+    }
+  }
+
+  /**
+    * Construct an instance of the given case class using reflection. Field names
+    * must match configuration keys exactly and supported types are String,
+    * Int and java.time.LocalDate.
+    */
+  def as[T: TypeTag: ClassTag]: T = {
+    val mirror = runtimeMirror(getClass.getClassLoader)
+    val tpe = typeOf[T]
+    val classSymbol = tpe.typeSymbol.asClass
+    val classMirror = mirror.reflectClass(classSymbol)
+    val ctor = tpe.decl(termNames.CONSTRUCTOR).asMethod
+    val params = ctor.paramLists.flatten
+
+    val values = params.map { p =>
+      val name = p.name.toString
+      val t = p.typeSignature
+      val opt =
+        if (t =:= typeOf[String]) getString(name)
+        else if (t =:= typeOf[Int]) getInt(name)
+        else if (t =:= typeOf[LocalDate]) getDate(name)
+        else {
+          errors += s"$name has unsupported type $t"
+          None
+        }
+      opt
+    }
+
+    assertValid()
+
+    val ctorMirror = classMirror.reflectConstructor(ctor)
+    ctorMirror(values.map(_.get): _*).asInstanceOf[T]
+  }
+}
+
+object MapConfigReader {
+  def apply(map: Map[String, String]): MapConfigReader = new MapConfigReader(map)
+
+  /** Convenience method to directly construct a case class from the map. */
+  def read[T: TypeTag: ClassTag](map: Map[String, String]): T =
+    MapConfigReader(map).as[T]
+}


### PR DESCRIPTION
## Summary
- collect all missing or invalid settings when loading `CalibrationInputDataGeneratorJob` config
- print all config errors before aborting
- extract common `MapConfigReader` so other jobs can reuse this validation
- allow `MapConfigReader` to construct case class configs automatically
- expose loaded config instance via `Config()` instead of individual getters

## Testing
- `sbt test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68649f771b0c8326ac53fb1d25d3c7a1