### PR TITLE
Introduce ConfigFactory for flexible config creation

### DIFF
--- a/audience/src/main/scala/com/thetradedesk/audience/utils/ConfigFactory.scala
+++ b/audience/src/main/scala/com/thetradedesk/audience/utils/ConfigFactory.scala
@@ -1,0 +1,11 @@
+package com.thetradedesk.audience.utils
+
+import scala.reflect.ClassTag
+import scala.reflect.runtime.universe._
+
+object ConfigFactory {
+  def fromMap[T: TypeTag: ClassTag](map: Map[String, String], postProcess: T => T = (t: T) => t): T = {
+    val raw = MapConfigReader.read[T](map)
+    postProcess(raw)
+  }
+}


### PR DESCRIPTION
## Summary
- add `ConfigFactory` utility
- remove `Config` object and use factory inline in `CalibrationInputDataGeneratorJob`

## Testing
- `sbt test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864b46d065083268420415d4ff2c400