### PR TITLE
Fix sbt build for audience

### DIFF
--- a/audience/build.sbt
+++ b/audience/build.sbt
@@ -1,15 +1,15 @@
 import java.time.{Clock, LocalDateTime}
 import sbtrelease.Vcs
 
-name := "audience"
+lazy val confetti = RootProject(file("../confetti"))
 
-version := "0.0.0"
-
-scalaVersion := "2.12.15"
-
-// For now, we can define a different spark version by passing -DsparkVersion
 val sparkVersion = sys.props.getOrElse("sparkVersion", "3.2.1")
 val prometheusVersion = "0.9.0"
+
+lazy val audience = (project in file(".")).dependsOn(confetti).settings(
+  name := "audience",
+  version := "0.0.0",
+  scalaVersion := "2.12.15",
 
 resolvers += "bintray-spark-packages" at "https://dl.bintray.com/spark-packages/maven/"
 
@@ -77,4 +77,5 @@ testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-oD")
 assembly / assemblyShadeRules := Seq(
   ShadeRule.rename("shapeless.**" -> "new_shapeless.@1").inAll,
   ShadeRule.rename("cats.kernel.**" -> s"new_cats.kernel.@1").inAll
+)
 )


### PR DESCRIPTION
## Summary
- make the audience sbt project depend on the local `confetti` module

## Testing
- `sbt clean compile` *(fails: `bash: sbt: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6864d542f42083269313cf6142f58dfc