### PR TITLE
Fix scala reflection compile errors

### DIFF
--- a/confetti/build.sbt
+++ b/confetti/build.sbt
@@ -8,6 +8,7 @@ val awsVersion = "1.12.654"
 
 libraryDependencies ++= Seq(
   "org.yaml" % "snakeyaml" % "2.2",
-  "com.amazonaws" % "aws-java-sdk-s3" % awsVersion
+  "com.amazonaws" % "aws-java-sdk-s3" % awsVersion,
+  "org.scala-lang" % "scala-reflect" % scalaVersion.value
 )
 


### PR DESCRIPTION
## Summary
- add scala-reflect dependency for Confetti project so TypeTag imports compile

## Testing
- `apt-get update`
- `apt-get install sbt` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_6864ea2bcf908326a6f465d0710b08e1