### PR TITLE
Centralize ETL job entrypoint and metrics

### DIFF
--- a/audience/src/main/scala/com/thetradedesk/audience/jobs/CalibrationInputDataGeneratorJob.scala
+++ b/audience/src/main/scala/com/thetradedesk/audience/jobs/CalibrationInputDataGeneratorJob.scala
@@ -36,13 +36,8 @@ object CalibrationInputDataGeneratorJob
     experimentName = config.getStringOption("confettiExperiment"),
     groupName = "audience",
     jobName = "CalibrationInputDataGeneratorJob") {
-
-  val prometheus = new PrometheusClient("AudienceCalibrationDataJob", "RSMCalibrationInputDataGeneratorJob")
-
-  def main(args: Array[String]): Unit = {
-    execute()
-    prometheus.pushMetrics()
-  }
+  override val prometheusAppName: String = "AudienceCalibrationDataJob"
+  override val prometheusJobName: String = "RSMCalibrationInputDataGeneratorJob"
 
   override def runETLPipeline(): Map[String, String] = {
     val conf = getConfig
@@ -133,5 +128,5 @@ abstract class CalibrationInputDataGenerator(prometheus: PrometheusClient) {
   }
 }
 
-object RSMCalibrationInputDataGenerator extends CalibrationInputDataGenerator(prometheus: PrometheusClient) {
+object RSMCalibrationInputDataGenerator extends CalibrationInputDataGenerator(prometheus) {
 }


### PR DESCRIPTION
## Summary
- default Prometheus app name no longer set; subclasses must supply it
- require subclasses to provide Prometheus job name
- update CalibrationInputDataGeneratorJob to supply both Prometheus names

## Testing
- `apt-get update`
- `apt-get install -y sbt` *(fails: Unable to locate package sbt)*
- `sbt test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864ecf05b688326a8b6125ca9e08596