### PR TITLE
Refactor hashing utility for Confetti

### DIFF
--- a/confetti/src/main/scala/com/thetradedesk/confetti/utils/HashUtils.scala
+++ b/confetti/src/main/scala/com/thetradedesk/confetti/utils/HashUtils.scala
@@ -1,0 +1,13 @@
+package com.thetradedesk.confetti.utils
+
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
+import java.util.Base64
+
+object HashUtils {
+  def sha256Base64(content: String): String = {
+    val digest = MessageDigest.getInstance("SHA-256").digest(content.getBytes(StandardCharsets.UTF_8))
+    Base64.getEncoder.encodeToString(digest)
+  }
+}
+

--- a/confetti/src/main/scala/com/thetradedesk/confetti/utils/S3Utils.scala
+++ b/confetti/src/main/scala/com/thetradedesk/confetti/utils/S3Utils.scala
@@ -1,0 +1,25 @@
+package com.thetradedesk.confetti.utils
+
+import com.amazonaws.regions.Regions
+import com.amazonaws.services.s3.{AmazonS3, AmazonS3ClientBuilder, AmazonS3URI}
+
+import java.io.ByteArrayInputStream
+import java.nio.charset.StandardCharsets
+
+object S3Utils {
+  private val s3Client: AmazonS3 = AmazonS3ClientBuilder.standard().withRegion(Regions.US_EAST_1).build()
+
+  def readFromS3(path: String): String = {
+    val uri = new AmazonS3URI(path)
+    val obj = s3Client.getObject(uri.getBucket, uri.getKey)
+    scala.io.Source.fromInputStream(obj.getObjectContent).mkString
+  }
+
+  def writeToS3(path: String, data: String): Unit = {
+    val uri = new AmazonS3URI(path)
+    val bytes = data.getBytes(StandardCharsets.UTF_8)
+    val is = new ByteArrayInputStream(bytes)
+    s3Client.putObject(uri.getBucket, uri.getKey, is, null)
+  }
+
+}


### PR DESCRIPTION
## Summary
- move hashing functionality to new `HashUtils`
- update Confetti classes to use new hash utility
- keep `S3Utils` focused on S3 read/write helpers

## Testing
- `sbt -error -batch compile` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686517a7068c8326a841735da2ef8465