### PR TITLE
Update config loading to use strings and extend MapConfigReader

### DIFF
--- a/confetti/src/main/scala/com/thetradedesk/confetti/AutoConfigResolvingETLJobBase.scala
+++ b/confetti/src/main/scala/com/thetradedesk/confetti/AutoConfigResolvingETLJobBase.scala
@@ -38,8 +38,7 @@ abstract class AutoConfigResolvingETLJobBase[C: TypeTag : ClassTag](env: String,
   private final def loadConfigAndRenderRuntimeConfig(): Unit = {
     val config = loader.loadConfig()
     configHash = HashUtils.sha256Base64(new Yaml().dump(config.asJava))
-    val stringMap = config.map { case (k, v) => k -> v.toString }
-    jobConfig = Some(utils.ConfigFactory.fromMap[C](stringMap))
+    jobConfig = Some(utils.ConfigFactory.fromMap[C](config))
   }
 
   /**

--- a/confetti/src/main/scala/com/thetradedesk/confetti/utils/MapConfigReader.scala
+++ b/confetti/src/main/scala/com/thetradedesk/confetti/utils/MapConfigReader.scala
@@ -34,6 +34,45 @@ class MapConfigReader(map: Map[String, String]) {
       None
   }
 
+  def getDouble(key: String): Option[Double] = map.get(key) match {
+    case Some(v) =>
+      Try(v.toDouble).toOption match {
+        case Some(d) => Some(d)
+        case None =>
+          errors += s"$key is expecting Double type"
+          None
+      }
+    case None =>
+      errors += s"$key does not exist"
+      None
+  }
+
+  def getLong(key: String): Option[Long] = map.get(key) match {
+    case Some(v) =>
+      Try(v.toLong).toOption match {
+        case Some(l) => Some(l)
+        case None =>
+          errors += s"$key is expecting Long type"
+          None
+      }
+    case None =>
+      errors += s"$key does not exist"
+      None
+  }
+
+  def getBoolean(key: String): Option[Boolean] = map.get(key) match {
+    case Some(v) =>
+      Try(v.toBoolean).toOption match {
+        case Some(b) => Some(b)
+        case None =>
+          errors += s"$key is expecting Boolean type"
+          None
+      }
+    case None =>
+      errors += s"$key does not exist"
+      None
+  }
+
   def getDate(key: String): Option[LocalDate] = map.get(key) match {
     case Some(v) =>
       Try(LocalDate.parse(v)).toOption match {
@@ -59,7 +98,7 @@ class MapConfigReader(map: Map[String, String]) {
   /**
     * Construct an instance of the given case class using reflection. Field names
     * must match configuration keys exactly and supported types are String,
-    * Int and java.time.LocalDate.
+    * Int, Long, Double, Boolean and java.time.LocalDate.
     */
   def as[T: TypeTag: ClassTag]: T = {
     val mirror = runtimeMirror(getClass.getClassLoader)
@@ -75,6 +114,9 @@ class MapConfigReader(map: Map[String, String]) {
       val opt =
         if (t =:= typeOf[String]) getString(name)
         else if (t =:= typeOf[Int]) getInt(name)
+        else if (t =:= typeOf[Double]) getDouble(name)
+        else if (t =:= typeOf[Long]) getLong(name)
+        else if (t =:= typeOf[Boolean]) getBoolean(name)
         else if (t =:= typeOf[LocalDate]) getDate(name)
         else {
           errors += s"$name has unsupported type $t"


### PR DESCRIPTION
## Summary
- return `Map[String, String]` from `BehavioralConfigLoader.loadConfig`
- simplify `AutoConfigResolvingETLJobBase` by removing extra string conversion
- temporarily disable nested runtime variable rendering
- add Double/Long/Boolean support to `MapConfigReader`

## Testing
- `scala -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68652dad39dc83269e78a8d024002fb6