### PR TITLE
Add CloudWatch logging of runtime configs

### DIFF
--- a/confetti/build.sbt
+++ b/confetti/build.sbt
@@ -18,6 +18,8 @@ resolvers += "TTDNexusReleases" at "https://nexus.adsrvr.org/repository/ttd-rele
 libraryDependencies ++= Seq(
   "org.yaml" % "snakeyaml" % "2.2",
   "com.amazonaws" % "aws-java-sdk-s3" % awsVersion,
+  "com.amazonaws" % "aws-java-sdk-logs" % awsVersion,
+  "log4j" % "log4j" % "1.2.17",
   "org.scala-lang" % "scala-reflect" % scalaVersion.value,
   "io.prometheus" % "simpleclient" % prometheusVersion,
   "io.prometheus" % "simpleclient_common" % prometheusVersion,

--- a/confetti/src/main/scala/com/thetradedesk/confetti/utils/CloudWatchAppender.scala
+++ b/confetti/src/main/scala/com/thetradedesk/confetti/utils/CloudWatchAppender.scala
@@ -1,0 +1,28 @@
+package com.thetradedesk.confetti.utils
+
+import org.apache.log4j.{AppenderSkeleton, Level, LoggingEvent}
+
+/**
+ * Log4j appender that writes log events to AWS CloudWatch using CloudWatchLogger.
+ *
+ * @param logGroup name of the CloudWatch log group
+ * @param logStream name of the log stream
+ */
+class CloudWatchAppender(val logGroup: String, val logStream: String) extends AppenderSkeleton {
+  private lazy val logger = CloudWatchLoggerFactory.getLogger(logGroup, logStream)
+
+  override def append(event: LoggingEvent): Unit = {
+    val message = if (layout != null) layout.format(event) else event.getRenderedMessage
+    event.getLevel match {
+      case Level.DEBUG => logger.debug(message)
+      case Level.INFO  => logger.info(message)
+      case Level.WARN  => logger.warn(message)
+      case Level.ERROR => logger.error(message)
+      case _           => logger.info(message)
+    }
+  }
+
+  override def close(): Unit = {}
+
+  override def requiresLayout(): Boolean = true
+}

--- a/confetti/src/main/scala/com/thetradedesk/confetti/utils/CloudWatchLogFactory.scala
+++ b/confetti/src/main/scala/com/thetradedesk/confetti/utils/CloudWatchLogFactory.scala
@@ -1,0 +1,24 @@
+package com.thetradedesk.confetti.utils
+
+import org.apache.log4j.{Logger, PatternLayout}
+
+/**
+ * Factory for obtaining log4j loggers that log to CloudWatch.
+ */
+object CloudWatchLogFactory {
+  /**
+   * Returns a logger for the given class and log group. A CloudWatch appender is
+   * attached using the class name as the log stream.
+   */
+  def getLogger(clazz: Class[_], logGroup: String): Logger = {
+    val logger = Logger.getLogger(clazz)
+    val appenderName = s"CloudWatch-${logGroup}-${clazz.getSimpleName}"
+    if (logger.getAppender(appenderName) == null) {
+      val appender = new CloudWatchAppender(logGroup, clazz.getSimpleName)
+      appender.setName(appenderName)
+      appender.setLayout(new PatternLayout("%d{ISO8601} %-5p %c - %m%n"))
+      logger.addAppender(appender)
+    }
+    logger
+  }
+}

--- a/confetti/src/main/scala/com/thetradedesk/confetti/utils/CloudWatchLogger.scala
+++ b/confetti/src/main/scala/com/thetradedesk/confetti/utils/CloudWatchLogger.scala
@@ -1,0 +1,83 @@
+package com.thetradedesk.confetti.utils
+
+import com.amazonaws.regions.Regions
+import com.amazonaws.services.logs.AWSLogsClientBuilder
+import com.amazonaws.services.logs.model._
+
+import scala.collection.JavaConverters._
+
+/**
+  * Simple logger that writes messages to AWS CloudWatch Logs.
+  *
+  * @param logGroup  name of the CloudWatch log group
+  * @param logStream name of the CloudWatch log stream
+  */
+class CloudWatchLogger(logGroup: String, logStream: String) {
+  // Import members from the companion object so we can access the shared
+  // AWSLogs client and helper functions without qualifying them.
+  import CloudWatchLogger._
+
+  // ensure the log group and stream exist on instantiation
+  ensureLogGroup(logGroup)
+  ensureLogStream(logGroup, logStream)
+
+  // Cache the next sequence token so we don't have to fetch it from CloudWatch
+  // for every log entry. It is refreshed after each putLogEvents call.
+  private var sequenceToken: Option[String] = getSequenceToken(logGroup, logStream)
+
+  def debug(message: String): Unit = log("DEBUG", message)
+  def info(message: String): Unit = log("INFO", message)
+  def warn(message: String): Unit = log("WARN", message)
+  def error(message: String): Unit = log("ERROR", message)
+
+  def log(level: String, message: String): Unit = {
+    val event = new InputLogEvent()
+      .withTimestamp(System.currentTimeMillis())
+      .withMessage(s"[$level] $message")
+
+    val request = new PutLogEventsRequest()
+      .withLogGroupName(logGroup)
+      .withLogStreamName(logStream)
+      .withLogEvents(java.util.Arrays.asList(event))
+
+    // Attach the cached sequence token if available. If CloudWatch returns a
+    // next token we update our cache for subsequent log calls.
+    sequenceToken.foreach(request.setSequenceToken)
+    val result = client.putLogEvents(request)
+    sequenceToken = Option(result.getNextSequenceToken)
+  }
+}
+
+// Companion object for CloudWatchLogger. In Scala, objects hold the equivalent
+// of static fields and methods. We keep the AWSLogs client here so all logger
+// instances share a single client.
+object CloudWatchLogger {
+  private val client = AWSLogsClientBuilder.standard()
+    .withRegion(Regions.US_EAST_1)
+    .build()
+
+  private def ensureLogGroup(group: String): Unit = {
+    val existing = client.describeLogGroups(new DescribeLogGroupsRequest()
+      .withLogGroupNamePrefix(group)).getLogGroups.asScala
+    if (!existing.exists(_.getLogGroupName == group)) {
+      client.createLogGroup(new CreateLogGroupRequest(group))
+    }
+  }
+
+  private def ensureLogStream(group: String, stream: String): Unit = {
+    val existing = client.describeLogStreams(new DescribeLogStreamsRequest(group)
+      .withLogStreamNamePrefix(stream)).getLogStreams.asScala
+    if (!existing.exists(_.getLogStreamName == stream)) {
+      client.createLogStream(new CreateLogStreamRequest(group, stream))
+    }
+  }
+
+  private def getSequenceToken(group: String, stream: String): Option[String] = {
+    val streams = client.describeLogStreams(new DescribeLogStreamsRequest(group)
+      .withLogStreamNamePrefix(stream)).getLogStreams.asScala
+    streams.headOption.flatMap(s => Option(s.getUploadSequenceToken))
+  }
+
+  def apply(logGroup: String, logStream: String): CloudWatchLogger =
+    new CloudWatchLogger(logGroup, logStream)
+}

--- a/confetti/src/main/scala/com/thetradedesk/confetti/utils/CloudWatchLoggerFactory.scala
+++ b/confetti/src/main/scala/com/thetradedesk/confetti/utils/CloudWatchLoggerFactory.scala
@@ -1,0 +1,14 @@
+package com.thetradedesk.confetti.utils
+
+/**
+ * Factory for creating CloudWatchLogger instances for a given
+ * log group and log stream. A new logger is created each time.
+ */
+object CloudWatchLoggerFactory {
+  /**
+   * Obtain a CloudWatchLogger for the provided log group and stream.
+   * A new logger instance is created on every call.
+   */
+  def getLogger(logGroup: String, logStream: String): CloudWatchLogger =
+    new CloudWatchLogger(logGroup, logStream)
+}


### PR DESCRIPTION
## Summary
- add AWS CloudWatch logging utilities
- log rendered configuration to CloudWatch
- include CloudWatch SDK dependency
- integrate CloudWatch logging with log4j
- introduce `CloudWatchLoggerFactory` to get loggers using factory pattern
- simplify the logger factory to always create a new logger instance
- clarify CloudWatchLogger usage and cache sequence tokens

## Testing
- `sbt -no-colors compile` *(fails: `sbt: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686548070924832692e9fb27fdfb466b