### PR TITLE
Refactor prometheus handling for Confetti ETL jobs

### DIFF
--- a/audience/src/main/scala/com/thetradedesk/audience/jobs/CalibrationInputDataGeneratorJob.scala
+++ b/audience/src/main/scala/com/thetradedesk/audience/jobs/CalibrationInputDataGeneratorJob.scala
@@ -36,8 +36,8 @@ object CalibrationInputDataGeneratorJob
     experimentName = config.getStringOption("confettiExperiment"),
     groupName = "audience",
     jobName = "CalibrationInputDataGeneratorJob") {
-  override val prometheusAppName: String = "AudienceCalibrationDataJob"
-  override val prometheusJobName: String = "RSMCalibrationInputDataGeneratorJob"
+  override val prometheus: Option[PrometheusClient] =
+    Some(new PrometheusClient("AudienceCalibrationDataJob", "RSMCalibrationInputDataGeneratorJob"))
 
   override def runETLPipeline(): Map[String, String] = {
     val conf = getConfig
@@ -128,5 +128,5 @@ abstract class CalibrationInputDataGenerator(prometheus: PrometheusClient) {
   }
 }
 
-object RSMCalibrationInputDataGenerator extends CalibrationInputDataGenerator(prometheus) {
+object RSMCalibrationInputDataGenerator extends CalibrationInputDataGenerator(prometheus.get) {
 }


### PR DESCRIPTION
## Summary
- refactor `AutoConfigResolvingETLJobBase` to accept an optional Prometheus client
- update `CalibrationInputDataGeneratorJob` to create a `PrometheusClient`
- push metrics only when a Prometheus client is provided

## Testing
- `apt-get install -y sbt` *(fails: Unable to locate package sbt)*

------
https://chatgpt.com/codex/tasks/task_e_6865f0c95d48832688a6ff9a86360cd9