### PR TITLE
Refactor audience jobs for AutoConfig

### DIFF
--- a/audience/src/main/scala/com/thetradedesk/audience/jobs/Imp2BrModelInferenceDataGenerator.scala
+++ b/audience/src/main/scala/com/thetradedesk/audience/jobs/Imp2BrModelInferenceDataGenerator.scala
@@ -9,20 +9,32 @@ import org.apache.spark.sql.functions._
 import com.thetradedesk.spark.TTDSparkContext.spark.implicits._
 import org.apache.spark.sql.SaveMode
 import org.apache.spark.sql.types.FloatType
+import com.thetradedesk.confetti.AutoConfigResolvingETLJobBase
 import com.thetradedesk.spark.util.TTDConfig.config
 
 import java.time.format.DateTimeFormatter
 import scala.collection.mutable.ArrayBuffer
+import java.time.LocalDateTime
 
-object Imp2BrModelInferenceDataGenerator {
+case class Imp2BrModelInferenceDataGeneratorConfig(
+  feature_path: String,
+  date_time: String
+)
+
+object Imp2BrModelInferenceDataGenerator
+  extends AutoConfigResolvingETLJobBase[Imp2BrModelInferenceDataGeneratorConfig](
+    env = config.getStringRequired("env"),
+    experimentName = config.getStringOption("experimentName"),
+    groupName = "audience",
+    jobName = "Imp2BrModelInferenceDataGenerator") {
+
+  override val prometheus: Option[PrometheusClient] = None
+
   /***
    * Generate RMSv2 BidRequest model offline prediction input dataset, based on BidImpression,
    * with sampling logic aligned with SIBv3
    */
   val bidImpressionsS3Path = BidsImpressions.BIDSIMPRESSIONSS3 + "prod/bidsimpressions/"
-  val modelVersion = s"${dateTime.format(DateTimeFormatter.ofPattern(audienceVersionDateFormat))}"
-  val featuresJsonPath= config.getString(
-    "feature_path", s"s3://thetradedesk-mlplatform-us-east-1/models/prod/RSM/full_model/${modelVersion}/features.json")
 
   def getAllUiidsUdfWithSample(sampleFun: String => Boolean) = udf((tdid: String, deviceAdvertisingId: String, uid2: String, euid: String, identityLinkId: String) => {
     val uiids = ArrayBuffer[String]()
@@ -47,7 +59,14 @@ object Imp2BrModelInferenceDataGenerator {
     uiids.toSeq
   })
 
-  def runETLPipeline(): Unit = {
+  override def runETLPipeline(): Map[String, String] = {
+    val conf = getConfig
+    val dt = LocalDateTime.parse(conf.date_time)
+    date = dt.toLocalDate
+    dateTime = dt
+
+    val featuresJsonPath = conf.feature_path
+
     val bidsImpressions = loadParquetData[BidsImpressionsSchema](bidImpressionsS3Path, date, lookBack=Some(0), source = Some(GERONIMO_DATA_SOURCE))
       .withColumn("Uiids", getAllUiidsUdfWithSample(_isDeviceIdSampled1Percent)('CookieTDID, 'DeviceAdvertisingId, 'UnifiedId2, 'EUID, 'IdentityLinkId))
       .withColumn("TDID", explode(col("Uiids")))
@@ -125,9 +144,6 @@ object Imp2BrModelInferenceDataGenerator {
         saveMode = SaveMode.Overwrite,
         numPartitions = Some(10000)
       )
+    Map("status" -> "success")
   }
-  def main(args: Array[String]): Unit = {
-    runETLPipeline()
-  }
-
 }

--- a/audience/src/main/scala/com/thetradedesk/audience/jobs/TdidEmbeddingDotProductGenerator.scala
+++ b/audience/src/main/scala/com/thetradedesk/audience/jobs/TdidEmbeddingDotProductGenerator.scala
@@ -4,6 +4,7 @@ package com.thetradedesk.audience.jobs
 import com.thetradedesk.audience.datasets.{CrossDeviceVendor, DataSource}
 import com.thetradedesk.spark.TTDSparkContext.spark
 import com.thetradedesk.spark.TTDSparkContext.spark.implicits._
+import com.thetradedesk.confetti.AutoConfigResolvingETLJobBase
 import com.thetradedesk.spark.util.TTDConfig.config
 import org.apache.spark.SparkContext
 import org.apache.spark.sql.expressions.UserDefinedFunction
@@ -13,8 +14,28 @@ import org.apache.spark.sql.types.{ArrayType, FloatType, IntegerType}
 
 import scala.collection.mutable
 import java.util.UUID
+import java.time.LocalDateTime
 
-object TdidEmbeddingDotProductGenerator {
+case class TdidEmbeddingDotProductGeneratorConfig(
+  out_path: String,
+  avail_path: String,
+  seed_density_path: String,
+  density_split: Int,
+  density_limit: Int,
+  tdid_limit: Int,
+  debug: Boolean,
+  partition: Int,
+  date_time: String
+)
+
+object TdidEmbeddingDotProductGenerator
+  extends AutoConfigResolvingETLJobBase[TdidEmbeddingDotProductGeneratorConfig](
+    env = config.getStringRequired("env"),
+    experimentName = config.getStringOption("experimentName"),
+    groupName = "audience",
+    jobName = "TdidEmbeddingDotProductGenerator") {
+
+  override val prometheus: Option[PrometheusClient] = None
   val salt="TRM"
   //val tdid_emb_path="s3://thetradedesk-mlplatform-us-east-1/users/youjun.yuan/rsmv2/emb/agg_tdid/"
   val tdid_emb_path="s3://thetradedesk-mlplatform-us-east-1/users/youjun.yuan/rsmv2/emb/agg_tdid/date=20250216/"
@@ -24,14 +45,7 @@ object TdidEmbeddingDotProductGenerator {
 //  val seed_list_path="s3://thetradedesk-mlplatform-us-east-1/data/prod/audience/relevanceseedsdataset/v=1/date=20250216/"
   val policy_table_path ="s3://thetradedesk-mlplatform-us-east-1/configdata/prod/audience/policyTable/RSM/v=1/20250216000000/"
   val seed_id_path ="s3://thetradedesk-mlplatform-us-east-1/data/dev/audience/scores/seedids/v=2/date=20250216/"
-  val out_path = config.getString("TdidEmbeddingDotProductGenerator.out_path", "s3://thetradedesk-mlplatform-us-east-1/data/dev/audience/scores/tdid2seedidV2/v=1/date=20250216/") // "s3://thetradedesk-mlplatform-us-east-1/users/youjun.yuan/rsmv2/emb/tdid2seedid/"
-  val avail_path = config.getString("TdidEmbeddingDotProductGenerator.avail_path", "s3://thetradedesk-mlplatform-us-east-1/data/prodTest/audience/RSMV2/Availycp-dup_plus/v=2/20250216000000/")
-  val seed_density_path = config.getString("TdidEmbeddingDotProductGenerator.seed_density_path", "s3://thetradedesk-mlplatform-us-east-1/features/feature_store/prodTest/profiles/source=bidsimpression/index=FeatureKeyValue/job=DailyDensityScoreReIndexingJob/config=SyntheticIdDensityScoreCategorized/date=20250216/")
-  val density_split = config.getInt("TdidEmbeddingDotProductGenerator.density_split", -1)
-  val density_limit = config.getInt("TdidEmbeddingDotProductGenerator.density_limit", -1)
-  val tdid_limit = config.getInt("TdidEmbeddingDotProductGenerator.tdid_limit", -1)
-  val debug = config.getBoolean("TdidEmbeddingDotProductGenerator.debug", false)
-  val partition = config.getInt("TdidEmbeddingDotProductGenerator.partition", -1)
+  val EmbeddingSize = 64
   val EmbeddingSize = 64
 
 //  val extractSubarray = udf { (group: Int, arr: Seq[Double]) =>
@@ -248,7 +262,20 @@ object TdidEmbeddingDotProductGenerator {
   val decodeTdid: UserDefinedFunction = udf(guidToLongs _)
 
   /////
-  def runETLPipeline(): Unit = {
+  override def runETLPipeline(): Map[String, String] = {
+    val conf = getConfig
+    val dt = LocalDateTime.parse(conf.date_time)
+    date = dt.toLocalDate
+    dateTime = dt
+
+    val out_path = conf.out_path
+    val avail_path = conf.avail_path
+    val seed_density_path = conf.seed_density_path
+    val density_split = conf.density_split
+    val density_limit = conf.density_limit
+    val tdid_limit = conf.tdid_limit
+    val debug = conf.debug
+    val partition = conf.partition
 //    val df_seed_list = spark.read.format("parquet").load(seed_list_path)
 //    val seeds = df_seed_list.collect()
 //    val SeedIds: Array[String] = seeds(0).getSeq(0).toArray[String]
@@ -378,11 +405,8 @@ object TdidEmbeddingDotProductGenerator {
         .option("codec", "org.apache.hadoop.io.compress.GzipCodec")
         .mode("overwrite")
         .save(out_path + f"split=${i}/")
-    })
-  }
-
-  def main(args: Array[String]): Unit = {
-    runETLPipeline()
+  })
+    Map("status" -> "success")
   }
 }
 

--- a/audience/src/main/scala/com/thetradedesk/audience/jobs/TdidSeedScoreScale.scala
+++ b/audience/src/main/scala/com/thetradedesk/audience/jobs/TdidSeedScoreScale.scala
@@ -3,30 +3,55 @@ package com.thetradedesk.audience.jobs
 import com.thetradedesk.audience.{date, dateFormatter, ttdEnv}
 import com.thetradedesk.spark.TTDSparkContext.spark
 import com.thetradedesk.spark.TTDSparkContext.spark.implicits._
+import com.thetradedesk.confetti.AutoConfigResolvingETLJobBase
 import com.thetradedesk.spark.util.TTDConfig.config
+import com.thetradedesk.spark.util.prometheus.PrometheusClient
 import org.apache.spark.sql.functions._
 
 
-object TdidSeedScoreScale {
-  val salt=config.getString("salt", "TRM")
+import java.time.LocalDateTime
 
-  val dateStr = date.format(dateFormatter)
-  val raw_score_path = config.getString("raw_score_path", s"s3://thetradedesk-mlplatform-us-east-1/data/${ttdEnv}/audience/scores/tdid2seedid_raw/v=1/date=${dateStr}/")
-  val seed_id_path = config.getString(
-    "seed_id_path", s"s3://thetradedesk-mlplatform-us-east-1/data/${ttdEnv}/audience/scores/seedids/v=2/date=${dateStr}/")
-  val policy_table_path = config.getString(
-    "policy_table_path", s"s3://thetradedesk-mlplatform-us-east-1/configdata/prod/audience/policyTable/RSM/v=1/${dateStr}000000/")
-  val out_path = config.getString("out_path", s"s3://thetradedesk-mlplatform-us-east-1/data/${ttdEnv}/audience/scores/tdid2seedid/v=1/date=${dateStr}/")
-  val population_score_path = config.getString("population_score_path", s"s3://thetradedesk-mlplatform-us-east-1/data/${ttdEnv}/audience/scores/seedpopulationscore/v=1/date=${dateStr}/")
+case class TdidSeedScoreScaleConfig(
+  salt: String,
+  raw_score_path: String,
+  seed_id_path: String,
+  policy_table_path: String,
+  out_path: String,
+  population_score_path: String,
+  smooth_factor: Double,
+  userLevelUpperCap: Double,
+  accuracy: Int,
+  sampleRateForPercentile: Double,
+  skipPercentile: Boolean,
+  date_time: String
+)
 
-  val smooth_factor = config.getDouble("smooth_factor", 30f).toFloat
-  val userLevelUpperCap = config.getDouble("userLevelUpperCap", 1e6f).toFloat
-  val accuracy = config.getInt("accuracy", 1000)
-  val sampleRateForPercentile = config.getDouble("sampleRateForPercentile", 0.3)
-  val skipPercentile = config.getBoolean("skipPercentile", true)
+object TdidSeedScoreScale
+  extends AutoConfigResolvingETLJobBase[TdidSeedScoreScaleConfig](
+    env = config.getStringRequired("env"),
+    experimentName = config.getStringOption("experimentName"),
+    groupName = "audience",
+    jobName = "TdidSeedScoreScale") {
+
+  override val prometheus: Option[PrometheusClient] = None
 
   /////
-  def runETLPipeline(): Unit = {
+  override def runETLPipeline(): Map[String, String] = {
+    val conf = getConfig
+    val dt = LocalDateTime.parse(conf.date_time)
+    date = dt.toLocalDate
+    val dateStr = date.format(dateFormatter)
+    val salt = conf.salt
+    val raw_score_path = conf.raw_score_path
+    val seed_id_path = conf.seed_id_path
+    val policy_table_path = conf.policy_table_path
+    val out_path = conf.out_path
+    val population_score_path = conf.population_score_path
+    val smooth_factor = conf.smooth_factor.toFloat
+    val userLevelUpperCap = conf.userLevelUpperCap.toFloat
+    val accuracy = conf.accuracy
+    val sampleRateForPercentile = conf.sampleRateForPercentile
+    val skipPercentile = conf.skipPercentile
     val df_seed_list = spark.read.format("parquet").load(seed_id_path)
     val seed_info = df_seed_list.collect()
     //val arrayLength = df_seed_list.select("SeedId").as[Seq[String]].first().length
@@ -107,9 +132,6 @@ object TdidSeedScoreScale {
       .mode("overwrite")
       .save(population_score_path)
 
-  }
-
-  def main(args: Array[String]): Unit = {
-    runETLPipeline()
+    Map("status" -> "success")
   }
 }


### PR DESCRIPTION
## Summary
- switch AudiencePolicyTableGenerator to auto-resolving configs
- refactor Imp2BrModelInferenceDataGenerator with runtime config
- refactor PopulationInputDataGeneratorJob for auto config
- add config-based setup for RelevanceModelInputGenerator
- update TdidEmbeddingDotProductGenerator to load config
- refactor TdidSeedScoreScale

## Testing
- `sbt test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b56a56fe88326aa71932d99054c92