### PR TITLE
Refactor audience policy jobs for case class config

### DIFF
--- a/audience/src/main/scala/com/thetradedesk/audience/jobs/policytable/AudiencePolicyTableGenerator.scala
+++ b/audience/src/main/scala/com/thetradedesk/audience/jobs/policytable/AudiencePolicyTableGenerator.scala
@@ -10,7 +10,7 @@ import com.thetradedesk.geronimo.bidsimpression.schema.{BidsImpressions, BidsImp
 import com.thetradedesk.geronimo.shared.{GERONIMO_DATA_SOURCE, loadParquetData}
 import com.thetradedesk.spark.TTDSparkContext.spark
 import com.thetradedesk.spark.TTDSparkContext.spark.implicits._
-import com.thetradedesk.spark.util.TTDConfig.config
+import com.thetradedesk.spark.util.TTDConfig.{config => ttdConfig}
 import com.thetradedesk.spark.util.prometheus.PrometheusClient
 import org.apache.spark.sql._
 import org.apache.spark.sql.expressions.Window
@@ -21,61 +21,60 @@ import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoUnit
 import java.time.{LocalDate, LocalDateTime}
 
-abstract class AudiencePolicyTableGenerator(model: Model) {
+case class AudiencePolicyTableJobConfig(
+  storageCloud: String,
+  seedMetaDataRecentVersion: String,
+  seedMetadataS3Bucket: String,
+  countryDensityThreshold: Double,
+  seedMetadataS3Path: String,
+  seedRawDataS3Bucket: String,
+  seedRawDataS3Path: String,
+  seedRawDataRecentVersion: String,
+  policyTableResetSyntheticId: Boolean,
+  conversionLookBack: Int,
+  expiredDays: Int,
+  policyTableLookBack: Int,
+  policyS3Bucket: String,
+  policyS3Path: String,
+  maxVersionsToKeep: Int,
+  reuseAggregatedSeedIfPossible: Boolean,
+  bidImpressionRepartitionNum: Int,
+  seedRepartitionNum: Int,
+  bidImpressionLookBack: Int,
+  graphUniqueCountKeepThreshold: Int,
+  graphScoreThreshold: Double,
+  seedJobParallel: Int,
+  seedProcessLowerThreshold: Long,
+  seedProcessUpperThreshold: Long,
+  ttdOwnDataUpperThreshold: Long,
+  seedExtendGraphUpperThreshold: Long,
+  activeUserRatio: Double,
+  aemPixelLimit: Int,
+  selectedPixelsConfigPath: String,
+  useSelectedPixel: Boolean,
+  campaignFlightStartingBufferInDays: Int,
+  allRSMSeed: Boolean,
+  activeAdvertiserLookBackDays: Int,
+  newSeedLookBackDays: Int,
+  date_time: String
+)
+
+abstract class AudiencePolicyTableGenerator(model: Model, config: AudiencePolicyTableJobConfig) {
 
   def getPrometheus: PrometheusClient
 
-  val userDownSampleHitPopulation = config.getInt(s"userDownSampleHitPopulation${model}", default = 100000)
-  val samplingFunction = shouldConsiderTDID3(userDownSampleHitPopulation, config.getStringRequired(s"saltToSampleUser${model}"))(_)
-  val arraySamplingFunction = shouldConsiderTDIDInArray3(userDownSampleHitPopulation, config.getStringRequired(s"saltToSampleUser${model}"))
+  val userDownSampleHitPopulation = ttdConfig.getInt(s"userDownSampleHitPopulation${model}", default = 100000)
+  val samplingFunction = shouldConsiderTDID3(userDownSampleHitPopulation, ttdConfig.getStringRequired(s"saltToSampleUser${model}"))(_)
+  val arraySamplingFunction = shouldConsiderTDIDInArray3(userDownSampleHitPopulation, ttdConfig.getStringRequired(s"saltToSampleUser${model}"))
   val jobRunningTime = getPrometheus.createGauge(s"audience_policy_table_job_running_time", "AudiencePolicyTableGenerator running time", "model", "date")
   val policyTableSize = getPrometheus.createGauge(s"audience_policy_table_size", "AudiencePolicyTableGenerator running time", "model", "date")
 
 
-  object Config {
-    // config to determine which cloud storage source to use
-    val storageCloud = StorageCloud.withName(config.getString("storageCloud", StorageCloud.AWS.toString)).id
-    // detect recent seed metadata path in airflow and pass to spark job
-    val seedMetaDataRecentVersion = config.getString("seedMetaDataRecentVersion", null)
-    val seedMetadataS3Bucket = S3Utils.refinePath(config.getString("seedMetadataS3Bucket", "ttd-datprd-us-east-1"))
-    val countryDensityThreshold = config.getDouble("countryDensityThreshold", 0.8)
-    val seedMetadataS3Path = S3Utils.refinePath(config.getString("seedMetadataS3Path", "prod/data/SeedDetail/v=1/"))
-    val seedRawDataS3Bucket = S3Utils.refinePath(config.getString("seedRawDataS3Bucket", "ttd-datprd-us-east-1"))
-    val seedRawDataS3Path = S3Utils.refinePath(config.getString("seedRawDataS3Path", "prod/data/Seed/v=1"))
-    val seedRawDataRecentVersion = config.getString("seedRawDataRecentVersion", null)
-    val policyTableResetSyntheticId = config.getBoolean("policyTableResetSyntheticId", false)
-    // conversion data look back days
-    val conversionLookBack = config.getInt("conversionLookBack", 5)
-    val expiredDays = config.getInt("expiredDays", default = 7)
-    val policyTableLookBack = config.getInt("policyTableLookBack", default = 3)
-    val policyS3Bucket = S3Utils.refinePath(config.getString("policyS3Bucket", "thetradedesk-mlplatform-us-east-1"))
-    val policyS3Path = S3Utils.refinePath(config.getString("policyS3Path", s"configdata/${ttdEnv}/audience/policyTable/${model}/v=1"))
-    val maxVersionsToKeep = config.getInt("maxVersionsToKeep", 30)
-    val reuseAggregatedSeedIfPossible = config.getBoolean("reuseAggregatedSeedIfPossible", true)
-    val bidImpressionRepartitionNum = config.getInt("bidImpressionRepartitionNum", 4096)
-    val seedRepartitionNum = config.getInt("seedRepartitionNum", 32)
-    val bidImpressionLookBack = config.getInt("bidImpressionLookBack", 1)
-    val graphUniqueCountKeepThreshold = config.getInt("graphUniqueCountKeepThreshold", 20)
-    val graphScoreThreshold = config.getDouble("graphScoreThreshold", 0.01)
-    val seedJobParallel = config.getInt("seedJobParallel", Runtime.getRuntime.availableProcessors())
-    val seedProcessLowerThreshold = config.getLong("seedProcessLowerThreshold", 2000)
-    val seedProcessUpperThreshold = config.getLong("seedProcessUpperThreshold", 100000000)
-    val ttdOwnDataUpperThreshold = config.getLong("ttdOwnDataUpperThreshold", 200000000)
-    val seedExtendGraphUpperThreshold = config.getLong("seedExtendGraphUpperThreshold", 3000000)
-    val activeUserRatio = config.getDouble("activeUserRatio", 0.4)
-    val aemPixelLimit = config.getInt("aemPixelLimit", 5000)
-    var selectedPixelsConfigPath = config.getString("selectedPixelsConfigPath", "s3a://thetradedesk-mlplatform-us-east-1/configdata/prodTest/audience/other/AEM/selectedPixelTrackingTagIds/")
-    var useSelectedPixel = config.getBoolean("useSelectedPixel", false)
-    var campaignFlightStartingBufferInDays = config.getInt("campaignFlightStartingBufferInDays", 14)
-    var allRSMSeed = config.getBoolean("allRSMSeed", false)
-    var activeAdvertiserLookBackDays = config.getInt("activeAdvertiserLookBackDays", 180)
-    var newSeedLookBackDays = config.getInt("newSeedLookBackDays", 7)
-  }
 
   private val policyTableDateFormatter = DateTimeFormatter.ofPattern(audienceVersionDateFormat)
 
   private val availablePolicyTableVersions = S3Utils
-    .queryCurrentDataVersions(Config.policyS3Bucket, Config.policyS3Path)
+    .queryCurrentDataVersions(config.policyS3Bucket, config.policyS3Path)
     .map(LocalDateTime.parse(_, policyTableDateFormatter))
     .toSeq
     .sortWith(_.isAfter(_))
@@ -88,9 +87,9 @@ abstract class AudiencePolicyTableGenerator(model: Model) {
 
     // read the seeddetail data again to join the advertiserid back to here
     val seedDataFullPath = SeedPolicyUtils.getRecentVersion(
-      Config.seedMetadataS3Bucket,
-      Config.seedMetadataS3Path,
-      Config.seedMetaDataRecentVersion
+      config.seedMetadataS3Bucket,
+      config.seedMetadataS3Path,
+      config.seedMetaDataRecentVersion
     )
     val seedAdvertiserMetaDataset = spark.read.parquet(seedDataFullPath)
         .select('SeedId.alias("SourceId"), 'AdvertiserId)
@@ -125,7 +124,7 @@ abstract class AudiencePolicyTableGenerator(model: Model) {
   }
 
   private def validateConfig(): Unit = {
-    if (ttdEnv == "prod" && Config.policyTableResetSyntheticId == true) {
+    if (ttdEnv == "prod" && config.policyTableResetSyntheticId == true) {
       throw new IllegalArgumentException("Cannot reset synthetic id for prod env")
     }
   }
@@ -136,7 +135,7 @@ abstract class AudiencePolicyTableGenerator(model: Model) {
     val baseDF = loadParquetData[BidsImpressionsSchema](
       bidImpressionsS3Path,
       date,
-      lookBack = Some(Config.bidImpressionLookBack),
+      lookBack = Some(config.bidImpressionLookBack),
       source = Some(GERONIMO_DATA_SOURCE)
     ).select('UIID, 'DeviceAdvertisingId, 'CookieTDID, 'IdentityLinkId, 'DATId, 'UnifiedId2, 'EUID, 'IdType)
       .cache()
@@ -145,7 +144,7 @@ abstract class AudiencePolicyTableGenerator(model: Model) {
       .filter(filterOnIdTypes(samplingFunction))
       .select(allIdWithType.alias("x"))
       .select(col("x._1").as("TDID"), col("x._2").as("idType"))
-      .repartition(Config.bidImpressionRepartitionNum, 'TDID)
+      .repartition(config.bidImpressionRepartitionNum, 'TDID)
       .withColumn("rn", row_number().over(Window.partitionBy("TDID").orderBy("idType")))
       .filter(col("rn") === 1) // Keep one idType per TDID following enum ordinal
       .drop("rn")
@@ -155,7 +154,7 @@ abstract class AudiencePolicyTableGenerator(model: Model) {
       .withColumn("TDID", getUiid('UIID, 'UnifiedId2, 'EUID, 'IdType))
       .filter(samplingFunction(col("TDID")))
       .select("TDID")
-      .repartition(Config.bidImpressionRepartitionNum, 'TDID)
+      .repartition(config.bidImpressionRepartitionNum, 'TDID)
       .distinct()
       .withColumn("IsOriginal", lit(1))
 
@@ -170,12 +169,12 @@ abstract class AudiencePolicyTableGenerator(model: Model) {
       if (crossDeviceVendor == CrossDeviceVendor.IAV2Person) {
         CrossDeviceGraphUtil
           .readGraphData(date, LightCrossDeviceGraphDataset())
-          .where(shouldTrackTDID('uiid) && 'score > lit(Config.graphScoreThreshold))
+          .where(shouldTrackTDID('uiid) && 'score > lit(config.graphScoreThreshold))
           .select('uiid.alias("TDID"), 'personId.alias("groupId"))
       } else if (crossDeviceVendor == CrossDeviceVendor.IAV2Household) {
         CrossDeviceGraphUtil
           .readGraphData(date, LightCrossDeviceHouseholdGraphDataset())
-          .where(shouldTrackTDID('uiid) && 'score > lit(Config.graphScoreThreshold))
+          .where(shouldTrackTDID('uiid) && 'score > lit(config.graphScoreThreshold))
           .select('uiid.alias("TDID"), 'householdID.alias("groupId"))
       } else {
         throw new UnsupportedOperationException(s"crossDeviceVendor ${crossDeviceVendor} is not supported")
@@ -191,10 +190,10 @@ abstract class AudiencePolicyTableGenerator(model: Model) {
 
   def generateGraphMapping(sourceGraph: DataFrame): DataFrame = {
     val graph = sourceGraph
-      .where(shouldTrackTDID('uiid) && 'score > lit(Config.graphScoreThreshold))
+      .where(shouldTrackTDID('uiid) && 'score > lit(config.graphScoreThreshold))
       .groupBy('groupId)
       .agg(collect_set('uiid).alias("TDID"))
-      .where(size('TDID) > lit(1) && size('TDID) <= lit(Config.graphUniqueCountKeepThreshold)) // remove persons with too many individuals or only one TDID
+      .where(size('TDID) > lit(1) && size('TDID) <= lit(config.graphUniqueCountKeepThreshold)) // remove persons with too many individuals or only one TDID
       .cache()
 
     val sampledGraph = graph
@@ -222,21 +221,21 @@ abstract class AudiencePolicyTableGenerator(model: Model) {
     // get retired sourceId
     val policyTableDayChange = ChronoUnit.DAYS.between(previousPolicyTableDate, date).toInt
 
-    val inActiveIds = previousPolicyTable.filter('StorageCloud === Config.storageCloud)
+    val inActiveIds = previousPolicyTable.filter('StorageCloud === config.storageCloud)
       .join(activeIds, Seq("SourceId", "Source", "CrossDeviceVendorId", "StorageCloud"), "left_anti")
       .withColumn("ExpiredDays", 'ExpiredDays + lit(policyTableDayChange))
 
-    val releasedIds = inActiveIds.filter('ExpiredDays > Config.expiredDays)
+    val releasedIds = inActiveIds.filter('ExpiredDays > config.expiredDays)
 
     val continueIds = previousPolicyTable.join(releasedIds, Seq("SyntheticId"), "left_anti")
 
-    val retentionIds = inActiveIds.filter('ExpiredDays <= Config.expiredDays)
+    val retentionIds = inActiveIds.filter('ExpiredDays <= config.expiredDays)
       .withColumn("IsActive", lit(false))
       .withColumn("Tag", lit(Tag.Retention.id))
       .withColumn("SampleWeight", lit(1.0))
 
     // get new sourceId
-    val newIds = activeIds.join(previousPolicyTable.filter('StorageCloud === Config.storageCloud)
+    val newIds = activeIds.join(previousPolicyTable.filter('StorageCloud === config.storageCloud)
       .select('SourceId, 'Source, 'CrossDeviceVendorId, 'StorageCloud), Seq("SourceId", "Source", "CrossDeviceVendorId", "StorageCloud"), "left_anti")
     val newIdsCount = newIds.count().toInt
     val releasedIdsCount = releasedIds.count().toInt
@@ -244,13 +243,13 @@ abstract class AudiencePolicyTableGenerator(model: Model) {
     val maxId = math.max(previousPolicyTable.agg(max('SyntheticId)).collect()(0)(0).asInstanceOf[Int], previousPolicyTable.count().toInt + newIdsCount - releasedIdsCount)
 
     val currentActiveIds = policyTable
-      .join(previousPolicyTable.filter('StorageCloud === Config.storageCloud).select('SourceId, 'Source, 'CrossDeviceVendorId, 'SyntheticId, 'IsActive, 'StorageCloud, 'MappingId), Seq("SourceId", "Source", "CrossDeviceVendorId", "StorageCloud"), "inner")
+      .join(previousPolicyTable.filter('StorageCloud === config.storageCloud).select('SourceId, 'Source, 'CrossDeviceVendorId, 'SyntheticId, 'IsActive, 'StorageCloud, 'MappingId), Seq("SourceId", "Source", "CrossDeviceVendorId", "StorageCloud"), "inner")
       .withColumn("ExpiredDays", lit(0))
       .withColumn("Tag", when('IsActive, lit(Tag.Existing.id)).otherwise(lit(Tag.Recall.id)))
       .withColumn("IsActive", lit(true))
       .withColumn("SampleWeight", lit(1.0)) // todo optimize this with performance/monitoring
 
-    val otherSourcePreviousPolicyTable = previousPolicyTable.filter('StorageCloud =!= Config.storageCloud).toDF()
+    val otherSourcePreviousPolicyTable = previousPolicyTable.filter('StorageCloud =!= config.storageCloud).toDF()
 
     val updatedPolicyTable =
       if (newIdsCount > 0) {
@@ -322,10 +321,10 @@ abstract class AudiencePolicyTableGenerator(model: Model) {
   def retrieveSourceData(date: LocalDate): DataFrame
 
   private def allocateSyntheticId(dateTime: LocalDateTime, policyTable: DataFrame): DataFrame = {
-    val recentVersionOption = if (Config.seedMetaDataRecentVersion != null) Some(LocalDateTime.parse(Config.seedMetaDataRecentVersion.split("=")(1), DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss.SSS")).toLocalDate.atStartOfDay())
+    val recentVersionOption = if (config.seedMetaDataRecentVersion != null) Some(LocalDateTime.parse(config.seedMetaDataRecentVersion.split("=")(1), DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss.SSS")).toLocalDate.atStartOfDay())
     else availablePolicyTableVersions.find(_.isBefore(dateTime))
 
-    if (!(recentVersionOption.isDefined) || Config.policyTableResetSyntheticId) {
+    if (!(recentVersionOption.isDefined) || config.policyTableResetSyntheticId) {
       val updatedPolicyTable = policyTable
         .withColumn("SyntheticId", row_number().over(Window.orderBy(rand())))
         .withColumn("SampleWeight", lit(1.0))
@@ -343,11 +342,11 @@ abstract class AudiencePolicyTableGenerator(model: Model) {
   }
 
   protected def activeUserRatio(dateTime: LocalDateTime): Double = {
-    val recentVersionOption = if (Config.seedMetaDataRecentVersion != null) Some(LocalDateTime.parse(Config.seedMetaDataRecentVersion.split("=")(1), DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss.SSS")).toLocalDate.atStartOfDay())
+    val recentVersionOption = if (config.seedMetaDataRecentVersion != null) Some(LocalDateTime.parse(config.seedMetaDataRecentVersion.split("=")(1), DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss.SSS")).toLocalDate.atStartOfDay())
     else availablePolicyTableVersions.find(_.isBefore(dateTime))
 
-    if (recentVersionOption.isEmpty || Config.policyTableResetSyntheticId) {
-      Config.activeUserRatio
+    if (recentVersionOption.isEmpty || config.policyTableResetSyntheticId) {
+      config.activeUserRatio
     } else {
       val previousPolicyTable = AudienceModelPolicyReadableDataset(model)
         .readSinglePartition(recentVersionOption.get)(spark).cache()


### PR DESCRIPTION
## Summary
- move AudiencePolicyTableGenerator settings into case class instance
- pass config to AudienceGraphPolicyTableGenerator and child jobs
- load config per-run in AEMGraphPolicyTableJob and RSMGraphPolicyTableJob

## Testing
- `sbt test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e1e96d9588326bc5376a759db2f3d