### PR TITLE
Adjust AutoConfigResolvingETLJobBase for pre-rendered configs

### DIFF
--- a/audience/src/main/scala/com/thetradedesk/audience/jobs/AudienceCalibrationAndMergeJob.scala
+++ b/audience/src/main/scala/com/thetradedesk/audience/jobs/AudienceCalibrationAndMergeJob.scala
@@ -37,6 +37,7 @@ object AudienceCalibrationAndMergeJob
   extends AutoConfigResolvingETLJobBase[AudienceCalibrationAndMergeJobConfig](
     env = config.getStringRequired("env"),
     experimentName = config.getStringOption("experimentName"),
+    runtimeConfigBasePath = config.getStringRequired("confetti_runtime_config_base_path"),
     groupName = "audience",
     jobName = "AudienceCalibrationAndMergeJob") {
   override val prometheus: Option[PrometheusClient] =

--- a/audience/src/main/scala/com/thetradedesk/audience/jobs/CalibrationInputDataGeneratorJob.scala
+++ b/audience/src/main/scala/com/thetradedesk/audience/jobs/CalibrationInputDataGeneratorJob.scala
@@ -31,6 +31,7 @@ object CalibrationInputDataGeneratorJob
   extends AutoConfigResolvingETLJobBase[CalibrationInputDataGeneratorJobConfig](
     env = config.getStringRequired("env"),
     experimentName = config.getStringOption("experimentName"),
+    runtimeConfigBasePath = config.getStringRequired("confetti_runtime_config_base_path"),
     groupName = "audience",
     jobName = "CalibrationInputDataGeneratorJob") {
   override val prometheus: Option[PrometheusClient] =

--- a/audience/src/main/scala/com/thetradedesk/audience/jobs/Imp2BrModelInferenceDataGenerator.scala
+++ b/audience/src/main/scala/com/thetradedesk/audience/jobs/Imp2BrModelInferenceDataGenerator.scala
@@ -25,6 +25,7 @@ object Imp2BrModelInferenceDataGenerator
   extends AutoConfigResolvingETLJobBase[Imp2BrModelInferenceDataGeneratorConfig](
     env = config.getStringRequired("env"),
     experimentName = config.getStringOption("experimentName"),
+    runtimeConfigBasePath = config.getStringRequired("confetti_runtime_config_base_path"),
     groupName = "audience",
     jobName = "Imp2BrModelInferenceDataGenerator") {
 

--- a/audience/src/main/scala/com/thetradedesk/audience/jobs/PopulationInputDataGeneratorJob.scala
+++ b/audience/src/main/scala/com/thetradedesk/audience/jobs/PopulationInputDataGeneratorJob.scala
@@ -47,6 +47,7 @@ object PopulationInputDataGeneratorJob
   extends AutoConfigResolvingETLJobBase[PopulationInputDataGeneratorJobConfig](
     env = config.getStringRequired("env"),
     experimentName = config.getStringOption("experimentName"),
+    runtimeConfigBasePath = config.getStringRequired("confetti_runtime_config_base_path"),
     groupName = "audience",
     jobName = "PopulationInputDataGeneratorJob") {
 

--- a/audience/src/main/scala/com/thetradedesk/audience/jobs/TdidEmbeddingDotProductGenerator.scala
+++ b/audience/src/main/scala/com/thetradedesk/audience/jobs/TdidEmbeddingDotProductGenerator.scala
@@ -32,6 +32,7 @@ object TdidEmbeddingDotProductGenerator
   extends AutoConfigResolvingETLJobBase[TdidEmbeddingDotProductGeneratorConfig](
     env = config.getStringRequired("env"),
     experimentName = config.getStringOption("experimentName"),
+    runtimeConfigBasePath = config.getStringRequired("confetti_runtime_config_base_path"),
     groupName = "audience",
     jobName = "TdidEmbeddingDotProductGenerator") {
 

--- a/audience/src/main/scala/com/thetradedesk/audience/jobs/TdidSeedScoreScale.scala
+++ b/audience/src/main/scala/com/thetradedesk/audience/jobs/TdidSeedScoreScale.scala
@@ -30,6 +30,7 @@ object TdidSeedScoreScale
   extends AutoConfigResolvingETLJobBase[TdidSeedScoreScaleConfig](
     env = config.getStringRequired("env"),
     experimentName = config.getStringOption("experimentName"),
+    runtimeConfigBasePath = config.getStringRequired("confetti_runtime_config_base_path"),
     groupName = "audience",
     jobName = "TdidSeedScoreScale") {
 

--- a/audience/src/main/scala/com/thetradedesk/audience/jobs/modelinput/rsmv2/RelevanceModelInputGeneratorJob.scala
+++ b/audience/src/main/scala/com/thetradedesk/audience/jobs/modelinput/rsmv2/RelevanceModelInputGeneratorJob.scala
@@ -24,6 +24,7 @@ object RelevanceModelInputGeneratorJob
   extends AutoConfigResolvingETLJobBase[RelevanceModelInputGeneratorJobConfig](
     env = config.getStringRequired("env"),
     experimentName = config.getStringOption("experimentName"),
+    runtimeConfigBasePath = config.getStringRequired("confetti_runtime_config_base_path"),
     groupName = "audience",
     jobName = "RelevanceModelInputGeneratorJob") {
   override val prometheus: Option[PrometheusClient] =

--- a/audience/src/main/scala/com/thetradedesk/audience/jobs/policytable/AEMGraphPolicyTableJob.scala
+++ b/audience/src/main/scala/com/thetradedesk/audience/jobs/policytable/AEMGraphPolicyTableJob.scala
@@ -20,6 +20,7 @@ object AEMGraphPolicyTableJob
   extends AutoConfigResolvingETLJobBase[AudiencePolicyTableJobConfig](
     env = ttdConfig.getStringRequired("env"),
     experimentName = ttdConfig.getStringOption("experimentName"),
+    runtimeConfigBasePath = ttdConfig.getStringRequired("confetti_runtime_config_base_path"),
     groupName = "audience",
     jobName = "AEMGraphPolicyTableJob") {
 

--- a/audience/src/main/scala/com/thetradedesk/audience/jobs/policytable/AEMPolicyTableGenerator.scala
+++ b/audience/src/main/scala/com/thetradedesk/audience/jobs/policytable/AEMPolicyTableGenerator.scala
@@ -18,6 +18,7 @@ object AEMPolicyTableGenerator
   extends AutoConfigResolvingETLJobBase[AudiencePolicyTableJobConfig](
     env = ttdConfig.getStringRequired("env"),
     experimentName = ttdConfig.getStringOption("experimentName"),
+    runtimeConfigBasePath = ttdConfig.getStringRequired("confetti_runtime_config_base_path"),
     groupName = "audience",
     jobName = "AEMPolicyTableGenerator") {
 

--- a/audience/src/main/scala/com/thetradedesk/audience/jobs/policytable/RSMGraphPolicyTableJob.scala
+++ b/audience/src/main/scala/com/thetradedesk/audience/jobs/policytable/RSMGraphPolicyTableJob.scala
@@ -24,6 +24,7 @@ object RSMGraphPolicyTableJob
   extends AutoConfigResolvingETLJobBase[AudiencePolicyTableJobConfig](
     env = ttdConfig.getStringRequired("env"),
     experimentName = ttdConfig.getStringOption("experimentName"),
+    runtimeConfigBasePath = ttdConfig.getStringRequired("confetti_runtime_config_base_path"),
     groupName = "audience",
     jobName = "RSMGraphPolicyTableJob") {
 

--- a/confetti/src/main/scala/com/thetradedesk/confetti/AutoConfigResolvingETLJobBase.scala
+++ b/confetti/src/main/scala/com/thetradedesk/confetti/AutoConfigResolvingETLJobBase.scala
@@ -1,10 +1,9 @@
 package com.thetradedesk.confetti
 
-import com.thetradedesk.confetti.utils.{CloudWatchLogger, CloudWatchLoggerFactory, HashUtils, S3Utils, MapConfigReader}
+import com.thetradedesk.confetti.utils.{CloudWatchLogger, CloudWatchLoggerFactory, MapConfigReader, S3Utils}
 import org.yaml.snakeyaml.Yaml
 import com.thetradedesk.spark.util.prometheus.PrometheusClient
 
-import java.time.LocalDateTime
 import scala.collection.JavaConverters._
 import scala.reflect.ClassTag
 import scala.reflect.runtime.universe._
@@ -16,18 +15,17 @@ import scala.reflect.runtime.universe._
 
 abstract class AutoConfigResolvingETLJobBase[C: TypeTag : ClassTag](env: String,
                                                                     experimentName: Option[String],
+                                                                    runtimeConfigBasePath: String,
                                                                     groupName: String,
                                                                     jobName: String) {
 
   /** Optional Prometheus client for pushing metrics. */
   protected val prometheus: Option[PrometheusClient]
 
-  private val loader = new BehavioralConfigLoader(env, experimentName, groupName, jobName)
   private val logger = CloudWatchLoggerFactory.getLogger(
     s"mlplatform-$env",
     s"${experimentName.filter(_.nonEmpty).map(n => s"$n-").getOrElse("")}$groupName-$jobName"
   )
-  private var configHash: String = _
   private var jobConfig: Option[C] = None
 
   /**
@@ -52,21 +50,28 @@ abstract class AutoConfigResolvingETLJobBase[C: TypeTag : ClassTag](env: String,
   def runETLPipeline(): Map[String, String]
 
   /** Executes the job by loading configuration, running the pipeline and writing the results. */
-  private final def execute(): Unit = {
-    // todo assemble runtime vars.
-    val runtimeVars = Map("date_time" -> LocalDateTime.now().toString)
+  private val runtimePathBase: String =
+    if (runtimeConfigBasePath.endsWith("/")) runtimeConfigBasePath else runtimeConfigBasePath + "/"
 
-    val config = loader.loadRuntimeConfigs(runtimeVars)
+  private final def execute(): Unit = {
+
+    val config = readYaml(runtimePathBase + "behavioral_config.yml")
     logger.info(new Yaml().dump(config.asJava))
     jobConfig = Some(new MapConfigReader(config, logger).as[C])
     if (jobConfig.isEmpty) {
       throw new IllegalStateException("Config not initialized")
     }
-    configHash = HashUtils.sha256Base64(new Yaml().dump(config.asJava))
-    val runtimePathBase = s"s3://thetradedesk-mlplatform-us-east-1/configdata/confetti/runtime-configs/$env/$groupName/$jobName/$configHash/"
-    writeYaml(config, runtimePathBase + "behavioral_config.yml")
+
     val result = runETLPipeline()
     writeYaml(result, runtimePathBase + "results.yml")
+  }
+
+  /** Read a YAML file from S3 into a map. */
+  private def readYaml(path: String): Map[String, String] = {
+    val yamlStr = S3Utils.readFromS3(path)
+    val yaml = new Yaml()
+    val javaMap = yaml.load[java.util.Map[String, Any]](yamlStr)
+    javaMap.asScala.map { case (k, v) => k -> v.toString }.toMap
   }
 
   /** Convert the map back to YAML and write it to the runtime config location. */


### PR DESCRIPTION
## Summary
- pass runtime config base path to `AutoConfigResolvingETLJobBase`
- update audience job objects to provide `confetti_runtime_config_base_path`

## Testing
- ❌ `sbt -no-colors test > ../sbt.log && tail -n 20 ../sbt.log`
- ❌ `scalac -version`

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_686f8516ac308326bfc26be35a2e28e0