### PR TITLE
Fix optional config handling in AudiencePolicyTableGenerator

### DIFF
--- a/audience/src/main/scala/com/thetradedesk/audience/jobs/AudienceCalibrationAndMergeJob.scala
+++ b/audience/src/main/scala/com/thetradedesk/audience/jobs/AudienceCalibrationAndMergeJob.scala
@@ -30,7 +30,7 @@ case class AudienceCalibrationAndMergeJobConfig(
   baselineHitRate: Double,
   recursiveWeight: Double,
   writeMode: String,
-  date_time: String
+  runDate: LocalDate
 )
 
 object AudienceCalibrationAndMergeJob
@@ -42,8 +42,8 @@ object AudienceCalibrationAndMergeJob
 
   override def runETLPipeline(): Map[String, String] = {
     val conf = getConfig
-    val dt = LocalDateTime.parse(conf.date_time)
-    date = dt.toLocalDate
+    val date = conf.runDate
+    val dateTime = conf.runDate.atStartOfDay()
 
     val jobConf = conf.copy(
       mlplatformS3Bucket = S3Utils.refinePath(conf.mlplatformS3Bucket),
@@ -54,7 +54,6 @@ object AudienceCalibrationAndMergeJob
     )
 
     val formatter = DateTimeFormatter.ofPattern("yyyyMMdd")
-    val dateTime = date.atStartOfDay()
 
     val embeddingTableDateFormatter = DateTimeFormatter.ofPattern(audienceVersionDateFormat)
     val availableEmbeddingVersions = S3Utils

--- a/audience/src/main/scala/com/thetradedesk/audience/jobs/AudienceCalibrationAndMergeJob.scala
+++ b/audience/src/main/scala/com/thetradedesk/audience/jobs/AudienceCalibrationAndMergeJob.scala
@@ -23,7 +23,7 @@ case class AudienceCalibrationAndMergeJobConfig(
   tmpSenEmbeddingDataS3Path: String,
   embeddingDataS3Path: String,
   inferenceDataS3Path: String,
-  embeddingRecentVersion: String,
+  embeddingRecentVersion: Option[String],
   anchorStartDate: LocalDate,
   smoothFactor: Double,
   locationFactor: Double,
@@ -62,10 +62,9 @@ object AudienceCalibrationAndMergeJob
     .toSeq
     .sortWith(_.isAfter(_))
 
-    val recentVersionOption =
-      if (jobConf.embeddingRecentVersion != null)
-        Some(LocalDateTime.parse(jobConf.embeddingRecentVersion, embeddingTableDateFormatter))
-      else availableEmbeddingVersions.find(_.isBefore(dateTime))
+    val recentVersionOption = jobConf.embeddingRecentVersion
+      .map(LocalDateTime.parse(_, embeddingTableDateFormatter))
+      .orElse(availableEmbeddingVersions.find(_.isBefore(dateTime)))
 
     val recentVersionStr = recentVersionOption.get.asInstanceOf[java.time.LocalDateTime].toLocalDate.format(formatter)
 

--- a/audience/src/main/scala/com/thetradedesk/audience/jobs/PopulationInputDataGeneratorJob.scala
+++ b/audience/src/main/scala/com/thetradedesk/audience/jobs/PopulationInputDataGeneratorJob.scala
@@ -23,7 +23,7 @@ case class PopulationInputDataGeneratorJobConfig(
                                                   inputDataS3Bucket: String,
                                                   inputDataS3Path: String,
                                                   populationOutputData3Path: String,
-                                                  customInputDataPath: String,
+                                                  customInputDataPath: Option[String],
                                                   subFolderKey: String,
                                                   subFolderValue: String,
                                                   syntheticIdLength: Int,

--- a/audience/src/main/scala/com/thetradedesk/audience/jobs/policytable/AEMGraphPolicyTableGeneratorJob.scala
+++ b/audience/src/main/scala/com/thetradedesk/audience/jobs/policytable/AEMGraphPolicyTableGeneratorJob.scala
@@ -16,9 +16,8 @@ object AEMGraphPolicyTableGeneratorJob
 
   override def runETLPipeline(): Map[String, String] = {
     val conf = getConfig
-    val dt = LocalDateTime.parse(conf.date_time)
-    date = dt.toLocalDate
-    dateTime = dt
+    date = conf.runDate
+    dateTime = conf.runDate.atStartOfDay()
     val generator = new AEMGraphPolicyTableGenerator(prometheus.get, conf)
     generator.generatePolicyTable()
     Map("status" -> "success")

--- a/audience/src/main/scala/com/thetradedesk/audience/jobs/policytable/AudiencePolicyTableGenerator.scala
+++ b/audience/src/main/scala/com/thetradedesk/audience/jobs/policytable/AudiencePolicyTableGenerator.scala
@@ -24,7 +24,7 @@ import java.time.{LocalDate, LocalDateTime}
 abstract class AudiencePolicyTableGenerator(
     model: Model,
     prometheus: PrometheusClient,
-    val Config: AudiencePolicyTableGeneratorConfig) {
+    val conf: AudiencePolicyTableGeneratorConfig) {
 
   val userDownSampleHitPopulation = config.getInt(s"userDownSampleHitPopulation${model}", default = 100000)
   val samplingFunction = shouldConsiderTDID3(userDownSampleHitPopulation, config.getStringRequired(s"saltToSampleUser${model}"))(_)
@@ -32,12 +32,10 @@ abstract class AudiencePolicyTableGenerator(
   val jobRunningTime = prometheus.createGauge(s"audience_policy_table_job_running_time", "AudiencePolicyTableGenerator running time", "model", "date")
   val policyTableSize = prometheus.createGauge(s"audience_policy_table_size", "AudiencePolicyTableGenerator running time", "model", "date")
 
-
-
   private val policyTableDateFormatter = DateTimeFormatter.ofPattern(audienceVersionDateFormat)
 
   private val availablePolicyTableVersions = S3Utils
-    .queryCurrentDataVersions(Config.policyS3Bucket, Config.policyS3Path)
+    .queryCurrentDataVersions(conf.policyS3Bucket, conf.policyS3Path)
     .map(LocalDateTime.parse(_, policyTableDateFormatter))
     .toSeq
     .sortWith(_.isAfter(_))
@@ -46,13 +44,16 @@ abstract class AudiencePolicyTableGenerator(
 
     validateConfig()
 
+    val date = conf.runDate
+    val dateTime = conf.runDate.atStartOfDay()
+
     val start = System.currentTimeMillis()
 
     // read the seeddetail data again to join the advertiserid back to here
     val seedDataFullPath = SeedPolicyUtils.getRecentVersion(
-      Config.seedMetadataS3Bucket,
-      Config.seedMetadataS3Path,
-      Config.seedMetaDataRecentVersion
+      conf.seedMetadataS3Bucket,
+      conf.seedMetadataS3Path,
+      conf.seedMetaDataRecentVersion
     )
     val seedAdvertiserMetaDataset = spark.read.parquet(seedDataFullPath)
         .select('SeedId.alias("SourceId"), 'AdvertiserId)
@@ -87,7 +88,7 @@ abstract class AudiencePolicyTableGenerator(
   }
 
   private def validateConfig(): Unit = {
-    if (ttdEnv == "prod" && Config.policyTableResetSyntheticId == true) {
+    if (ttdEnv == "prod" && conf.policyTableResetSyntheticId == true) {
       throw new IllegalArgumentException("Cannot reset synthetic id for prod env")
     }
   }
@@ -98,7 +99,7 @@ abstract class AudiencePolicyTableGenerator(
     val baseDF = loadParquetData[BidsImpressionsSchema](
       bidImpressionsS3Path,
       date,
-      lookBack = Some(Config.bidImpressionLookBack),
+      lookBack = Some(conf.bidImpressionLookBack),
       source = Some(GERONIMO_DATA_SOURCE)
     ).select('UIID, 'DeviceAdvertisingId, 'CookieTDID, 'IdentityLinkId, 'DATId, 'UnifiedId2, 'EUID, 'IdType)
       .cache()
@@ -107,7 +108,7 @@ abstract class AudiencePolicyTableGenerator(
       .filter(filterOnIdTypes(samplingFunction))
       .select(allIdWithType.alias("x"))
       .select(col("x._1").as("TDID"), col("x._2").as("idType"))
-      .repartition(Config.bidImpressionRepartitionNum, 'TDID)
+      .repartition(conf.bidImpressionRepartitionNum, 'TDID)
       .withColumn("rn", row_number().over(Window.partitionBy("TDID").orderBy("idType")))
       .filter(col("rn") === 1) // Keep one idType per TDID following enum ordinal
       .drop("rn")
@@ -117,7 +118,7 @@ abstract class AudiencePolicyTableGenerator(
       .withColumn("TDID", getUiid('UIID, 'UnifiedId2, 'EUID, 'IdType))
       .filter(samplingFunction(col("TDID")))
       .select("TDID")
-      .repartition(Config.bidImpressionRepartitionNum, 'TDID)
+      .repartition(conf.bidImpressionRepartitionNum, 'TDID)
       .distinct()
       .withColumn("IsOriginal", lit(1))
 
@@ -132,12 +133,12 @@ abstract class AudiencePolicyTableGenerator(
       if (crossDeviceVendor == CrossDeviceVendor.IAV2Person) {
         CrossDeviceGraphUtil
           .readGraphData(date, LightCrossDeviceGraphDataset())
-          .where(shouldTrackTDID('uiid) && 'score > lit(Config.graphScoreThreshold))
+          .where(shouldTrackTDID('uiid) && 'score > lit(conf.graphScoreThreshold))
           .select('uiid.alias("TDID"), 'personId.alias("groupId"))
       } else if (crossDeviceVendor == CrossDeviceVendor.IAV2Household) {
         CrossDeviceGraphUtil
           .readGraphData(date, LightCrossDeviceHouseholdGraphDataset())
-          .where(shouldTrackTDID('uiid) && 'score > lit(Config.graphScoreThreshold))
+          .where(shouldTrackTDID('uiid) && 'score > lit(conf.graphScoreThreshold))
           .select('uiid.alias("TDID"), 'householdID.alias("groupId"))
       } else {
         throw new UnsupportedOperationException(s"crossDeviceVendor ${crossDeviceVendor} is not supported")
@@ -153,10 +154,10 @@ abstract class AudiencePolicyTableGenerator(
 
   def generateGraphMapping(sourceGraph: DataFrame): DataFrame = {
     val graph = sourceGraph
-      .where(shouldTrackTDID('uiid) && 'score > lit(Config.graphScoreThreshold))
+      .where(shouldTrackTDID('uiid) && 'score > lit(conf.graphScoreThreshold))
       .groupBy('groupId)
       .agg(collect_set('uiid).alias("TDID"))
-      .where(size('TDID) > lit(1) && size('TDID) <= lit(Config.graphUniqueCountKeepThreshold)) // remove persons with too many individuals or only one TDID
+      .where(size('TDID) > lit(1) && size('TDID) <= lit(conf.graphUniqueCountKeepThreshold)) // remove persons with too many individuals or only one TDID
       .cache()
 
     val sampledGraph = graph
@@ -184,21 +185,21 @@ abstract class AudiencePolicyTableGenerator(
     // get retired sourceId
     val policyTableDayChange = ChronoUnit.DAYS.between(previousPolicyTableDate, date).toInt
 
-    val inActiveIds = previousPolicyTable.filter('StorageCloud === Config.storageCloud)
+    val inActiveIds = previousPolicyTable.filter('StorageCloud === conf.storageCloud)
       .join(activeIds, Seq("SourceId", "Source", "CrossDeviceVendorId", "StorageCloud"), "left_anti")
       .withColumn("ExpiredDays", 'ExpiredDays + lit(policyTableDayChange))
 
-    val releasedIds = inActiveIds.filter('ExpiredDays > Config.expiredDays)
+    val releasedIds = inActiveIds.filter('ExpiredDays > conf.expiredDays)
 
     val continueIds = previousPolicyTable.join(releasedIds, Seq("SyntheticId"), "left_anti")
 
-    val retentionIds = inActiveIds.filter('ExpiredDays <= Config.expiredDays)
+    val retentionIds = inActiveIds.filter('ExpiredDays <= conf.expiredDays)
       .withColumn("IsActive", lit(false))
       .withColumn("Tag", lit(Tag.Retention.id))
       .withColumn("SampleWeight", lit(1.0))
 
     // get new sourceId
-    val newIds = activeIds.join(previousPolicyTable.filter('StorageCloud === Config.storageCloud)
+    val newIds = activeIds.join(previousPolicyTable.filter('StorageCloud === conf.storageCloud)
       .select('SourceId, 'Source, 'CrossDeviceVendorId, 'StorageCloud), Seq("SourceId", "Source", "CrossDeviceVendorId", "StorageCloud"), "left_anti")
     val newIdsCount = newIds.count().toInt
     val releasedIdsCount = releasedIds.count().toInt
@@ -206,13 +207,13 @@ abstract class AudiencePolicyTableGenerator(
     val maxId = math.max(previousPolicyTable.agg(max('SyntheticId)).collect()(0)(0).asInstanceOf[Int], previousPolicyTable.count().toInt + newIdsCount - releasedIdsCount)
 
     val currentActiveIds = policyTable
-      .join(previousPolicyTable.filter('StorageCloud === Config.storageCloud).select('SourceId, 'Source, 'CrossDeviceVendorId, 'SyntheticId, 'IsActive, 'StorageCloud, 'MappingId), Seq("SourceId", "Source", "CrossDeviceVendorId", "StorageCloud"), "inner")
+      .join(previousPolicyTable.filter('StorageCloud === conf.storageCloud).select('SourceId, 'Source, 'CrossDeviceVendorId, 'SyntheticId, 'IsActive, 'StorageCloud, 'MappingId), Seq("SourceId", "Source", "CrossDeviceVendorId", "StorageCloud"), "inner")
       .withColumn("ExpiredDays", lit(0))
       .withColumn("Tag", when('IsActive, lit(Tag.Existing.id)).otherwise(lit(Tag.Recall.id)))
       .withColumn("IsActive", lit(true))
       .withColumn("SampleWeight", lit(1.0)) // todo optimize this with performance/monitoring
 
-    val otherSourcePreviousPolicyTable = previousPolicyTable.filter('StorageCloud =!= Config.storageCloud).toDF()
+    val otherSourcePreviousPolicyTable = previousPolicyTable.filter('StorageCloud =!= conf.storageCloud).toDF()
 
     val updatedPolicyTable =
       if (newIdsCount > 0) {
@@ -284,10 +285,10 @@ abstract class AudiencePolicyTableGenerator(
   def retrieveSourceData(date: LocalDate): DataFrame
 
   private def allocateSyntheticId(dateTime: LocalDateTime, policyTable: DataFrame): DataFrame = {
-    val recentVersionOption = if (Config.seedMetaDataRecentVersion != null) Some(LocalDateTime.parse(Config.seedMetaDataRecentVersion.split("=")(1), DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss.SSS")).toLocalDate.atStartOfDay())
+    val recentVersionOption = if (conf.seedMetaDataRecentVersion != null) Some(LocalDateTime.parse(conf.seedMetaDataRecentVersion.split("=")(1), DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss.SSS")).toLocalDate.atStartOfDay())
     else availablePolicyTableVersions.find(_.isBefore(dateTime))
 
-    if (!(recentVersionOption.isDefined) || Config.policyTableResetSyntheticId) {
+    if (!(recentVersionOption.isDefined) || conf.policyTableResetSyntheticId) {
       val updatedPolicyTable = policyTable
         .withColumn("SyntheticId", row_number().over(Window.orderBy(rand())))
         .withColumn("SampleWeight", lit(1.0))
@@ -305,11 +306,11 @@ abstract class AudiencePolicyTableGenerator(
   }
 
   protected def activeUserRatio(dateTime: LocalDateTime): Double = {
-    val recentVersionOption = if (Config.seedMetaDataRecentVersion != null) Some(LocalDateTime.parse(Config.seedMetaDataRecentVersion.split("=")(1), DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss.SSS")).toLocalDate.atStartOfDay())
+    val recentVersionOption = if (conf.seedMetaDataRecentVersion != null) Some(LocalDateTime.parse(conf.seedMetaDataRecentVersion.split("=")(1), DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss.SSS")).toLocalDate.atStartOfDay())
     else availablePolicyTableVersions.find(_.isBefore(dateTime))
 
-    if (recentVersionOption.isEmpty || Config.policyTableResetSyntheticId) {
-      Config.activeUserRatio
+    if (recentVersionOption.isEmpty || conf.policyTableResetSyntheticId) {
+      conf.activeUserRatio
     } else {
       val previousPolicyTable = AudienceModelPolicyReadableDataset(model)
         .readSinglePartition(recentVersionOption.get)(spark).cache()

--- a/audience/src/main/scala/com/thetradedesk/audience/jobs/policytable/AudiencePolicyTableGenerator.scala
+++ b/audience/src/main/scala/com/thetradedesk/audience/jobs/policytable/AudiencePolicyTableGenerator.scala
@@ -285,8 +285,12 @@ abstract class AudiencePolicyTableGenerator(
   def retrieveSourceData(date: LocalDate): DataFrame
 
   private def allocateSyntheticId(dateTime: LocalDateTime, policyTable: DataFrame): DataFrame = {
-    val recentVersionOption = if (conf.seedMetaDataRecentVersion != null) Some(LocalDateTime.parse(conf.seedMetaDataRecentVersion.split("=")(1), DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss.SSS")).toLocalDate.atStartOfDay())
-    else availablePolicyTableVersions.find(_.isBefore(dateTime))
+    val recentVersionOption = conf.seedMetaDataRecentVersion
+      .map(v => LocalDateTime
+        .parse(v.split("=")(1), DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss.SSS"))
+        .toLocalDate
+        .atStartOfDay())
+      .orElse(availablePolicyTableVersions.find(_.isBefore(dateTime)))
 
     if (!(recentVersionOption.isDefined) || conf.policyTableResetSyntheticId) {
       val updatedPolicyTable = policyTable
@@ -306,8 +310,12 @@ abstract class AudiencePolicyTableGenerator(
   }
 
   protected def activeUserRatio(dateTime: LocalDateTime): Double = {
-    val recentVersionOption = if (conf.seedMetaDataRecentVersion != null) Some(LocalDateTime.parse(conf.seedMetaDataRecentVersion.split("=")(1), DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss.SSS")).toLocalDate.atStartOfDay())
-    else availablePolicyTableVersions.find(_.isBefore(dateTime))
+    val recentVersionOption = conf.seedMetaDataRecentVersion
+      .map(v => LocalDateTime
+        .parse(v.split("=")(1), DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss.SSS"))
+        .toLocalDate
+        .atStartOfDay())
+      .orElse(availablePolicyTableVersions.find(_.isBefore(dateTime)))
 
     if (recentVersionOption.isEmpty || conf.policyTableResetSyntheticId) {
       conf.activeUserRatio

--- a/audience/src/main/scala/com/thetradedesk/audience/jobs/policytable/AudiencePolicyTableGeneratorConfig.scala
+++ b/audience/src/main/scala/com/thetradedesk/audience/jobs/policytable/AudiencePolicyTableGeneratorConfig.scala
@@ -4,13 +4,13 @@ import java.time.LocalDate
 
 case class AudiencePolicyTableGeneratorConfig(
   storageCloud: String,
-  seedMetaDataRecentVersion: String,
+  seedMetaDataRecentVersion: Option[String],
   seedMetadataS3Bucket: String,
   countryDensityThreshold: Double,
   seedMetadataS3Path: String,
   seedRawDataS3Bucket: String,
   seedRawDataS3Path: String,
-  seedRawDataRecentVersion: String,
+  seedRawDataRecentVersion: Option[String],
   policyTableResetSyntheticId: Boolean,
   conversionLookBack: Int,
   expiredDays: Int,

--- a/audience/src/main/scala/com/thetradedesk/audience/jobs/policytable/AudiencePolicyTableGeneratorConfig.scala
+++ b/audience/src/main/scala/com/thetradedesk/audience/jobs/policytable/AudiencePolicyTableGeneratorConfig.scala
@@ -1,5 +1,7 @@
 package com.thetradedesk.audience.jobs.policytable
 
+import java.time.LocalDate
+
 case class AudiencePolicyTableGeneratorConfig(
   storageCloud: Int,
   seedMetaDataRecentVersion: String,
@@ -35,5 +37,5 @@ case class AudiencePolicyTableGeneratorConfig(
   allRSMSeed: Boolean,
   activeAdvertiserLookBackDays: Int,
   newSeedLookBackDays: Int,
-  date_time: String
+  runDate: LocalDate
 )

--- a/audience/src/main/scala/com/thetradedesk/audience/jobs/policytable/AudiencePolicyTableGeneratorConfig.scala
+++ b/audience/src/main/scala/com/thetradedesk/audience/jobs/policytable/AudiencePolicyTableGeneratorConfig.scala
@@ -3,7 +3,7 @@ package com.thetradedesk.audience.jobs.policytable
 import java.time.LocalDate
 
 case class AudiencePolicyTableGeneratorConfig(
-  storageCloud: Int,
+  storageCloud: String,
   seedMetaDataRecentVersion: String,
   seedMetadataS3Bucket: String,
   countryDensityThreshold: Double,

--- a/audience/src/main/scala/com/thetradedesk/audience/jobs/policytable/RSMGraphPolicyTableGeneratorJob.scala
+++ b/audience/src/main/scala/com/thetradedesk/audience/jobs/policytable/RSMGraphPolicyTableGeneratorJob.scala
@@ -16,9 +16,6 @@ object RSMGraphPolicyTableGeneratorJob
 
   override def runETLPipeline(): Map[String, String] = {
     val conf = getConfig
-    val dt = LocalDateTime.parse(conf.date_time)
-    date = dt.toLocalDate
-    dateTime = dt
     val generator = new RSMGraphPolicyTableGenerator(prometheus.get, conf)
     generator.generatePolicyTable()
     Map("status" -> "success")

--- a/audience/src/main/scala/com/thetradedesk/audience/utils/S3Utils.scala
+++ b/audience/src/main/scala/com/thetradedesk/audience/utils/S3Utils.scala
@@ -31,11 +31,8 @@ object S3Utils {
 }
 
 object SeedPolicyUtils {
-  def getRecentVersion(bucket: String, path: String, recentVersion: String): String = {
-    val resolvedVersion = 
-      if (recentVersion != null) recentVersion 
-      else S3Utils.queryCurrentDataVersion(bucket, path)
-    
+  def getRecentVersion(bucket: String, path: String, recentVersion: Option[String]): String = {
+    val resolvedVersion = recentVersion.getOrElse(S3Utils.queryCurrentDataVersion(bucket, path))
     s"s3a://$bucket/$path/$resolvedVersion"
   }
 }


### PR DESCRIPTION
## Summary
- use `Option` when parsing `seedMetaDataRecentVersion`
- allow `embeddingRecentVersion` to be optional

## Testing
- `sbt clean compile -Dsbt.log.noformat=true` *(fails: bad constant pool index)*

------
https://chatgpt.com/codex/tasks/task_e_68788fece6888326af7a1c4146229ffd