### PR TITLE
Fix serialization for audience ETL job objects

### DIFF
--- a/audience/src/main/scala/com/thetradedesk/audience/jobs/TdidEmbeddingAggregate.scala
+++ b/audience/src/main/scala/com/thetradedesk/audience/jobs/TdidEmbeddingAggregate.scala
@@ -14,12 +14,7 @@ import java.nio.charset.StandardCharsets
 
 
 
-object TdidEmbeddingAggregate
-  extends AutoConfigResolvingETLJobBase[RelevanceModelOfflineScoringPart2Config](
-    groupName = "audience",
-    jobName   = "TdidEmbeddingAggregate") {
-
-  override val prometheus = None
+class TdidEmbeddingAggregate {
 
   case class Buffer(sums: Array[Double], var count: Long)
 
@@ -71,8 +66,7 @@ object TdidEmbeddingAggregate
   val emb_avg = udaf(RelevanceScoresAggregator)
   val utf8ToStringUdf = udf((bytes: Array[Byte]) => new String(bytes, StandardCharsets.UTF_8))
 
-  override def runETLPipeline(): Unit = {
-    val conf = getConfig
+  def run(conf: RelevanceModelOfflineScoringPart2Config): Unit = {
     val salt = conf.salt
     val br_emb_path = conf.br_emb_path
     val tdid_emb_path = conf.tdid_emb_path
@@ -96,5 +90,17 @@ object TdidEmbeddingAggregate
       .mode("overwrite")
       .option("codec", "org.apache.hadoop.io.compress.GzipCodec")
       .save(tdid_emb_path)
+  }
+}
+
+object TdidEmbeddingAggregate
+  extends AutoConfigResolvingETLJobBase[RelevanceModelOfflineScoringPart2Config](
+    groupName = "audience",
+    jobName   = "TdidEmbeddingAggregate") {
+
+  override val prometheus = None
+  override def runETLPipeline(): Unit = {
+    val conf = getConfig
+    new TdidEmbeddingAggregate().run(conf)
   }
 }

--- a/audience/src/main/scala/com/thetradedesk/audience/jobs/TdidEmbeddingDotProductGeneratorOOS.scala
+++ b/audience/src/main/scala/com/thetradedesk/audience/jobs/TdidEmbeddingDotProductGeneratorOOS.scala
@@ -16,13 +16,7 @@ import java.util.UUID
 import java.nio.ByteBuffer
 import java.security.MessageDigest
 
-object TdidEmbeddingDotProductGeneratorOOS
-  extends AutoConfigResolvingETLJobBase[RelevanceModelOfflineScoringPart2Config](
-    groupName = "audience",
-    jobName = "TdidEmbeddingDotProductGeneratorOOS") {
-
-  override val prometheus: Option[PrometheusClient] =
-    Some(new PrometheusClient("AudienceModelJob", "TdidEmbeddingDotProductGeneratorOOS"))
+class TdidEmbeddingDotProductGeneratorOOS {
 
   val EmbeddingSize = 64
 
@@ -56,9 +50,7 @@ object TdidEmbeddingDotProductGeneratorOOS
   }
   val convertUID2ToGUIDUDF = udf(convertUID2ToGUID _)
 
-  /////
-  override def runETLPipeline(): Unit = {
-    val conf = getConfig
+  def run(conf: RelevanceModelOfflineScoringPart2Config): Unit = {
 
     val tdid_emb_path = conf.tdid_emb_path
     val seed_emb_path = conf.seed_emb_path
@@ -184,6 +176,20 @@ object TdidEmbeddingDotProductGeneratorOOS
         .mode("overwrite")
         .save(out_path + f"split=${i}/")
     })
+  }
+}
+
+object TdidEmbeddingDotProductGeneratorOOS
+  extends AutoConfigResolvingETLJobBase[RelevanceModelOfflineScoringPart2Config](
+    groupName = "audience",
+    jobName = "TdidEmbeddingDotProductGeneratorOOS") {
+
+  override val prometheus: Option[PrometheusClient] =
+    Some(new PrometheusClient("AudienceModelJob", "TdidEmbeddingDotProductGeneratorOOS"))
+
+  override def runETLPipeline(): Unit = {
+    val conf = getConfig
+    new TdidEmbeddingDotProductGeneratorOOS().run(conf)
   }
 }
 

--- a/audience/src/main/scala/com/thetradedesk/audience/jobs/TdidSeedScoreScale.scala
+++ b/audience/src/main/scala/com/thetradedesk/audience/jobs/TdidSeedScoreScale.scala
@@ -9,16 +9,8 @@ import org.apache.spark.sql.functions._
 
 import java.time.{LocalDate, LocalDateTime}
 
-object TdidSeedScoreScale
-  extends AutoConfigResolvingETLJobBase[RelevanceModelOfflineScoringPart2Config](
-    groupName = "audience",
-    jobName = "TdidSeedScoreScale") {
-
-  override val prometheus: Option[PrometheusClient] = None
-
-  /////
-  override def runETLPipeline(): Unit = {
-    val conf = getConfig
+class TdidSeedScoreScale {
+  def run(conf: RelevanceModelOfflineScoringPart2Config): Unit = {
     date = conf.runDate
     val dateStr = date.format(dateFormatter)
     val salt = conf.salt
@@ -112,5 +104,18 @@ object TdidSeedScoreScale
         .mode("overwrite")
         .save(population_score_path)
 
+  }
+}
+
+object TdidSeedScoreScale
+  extends AutoConfigResolvingETLJobBase[RelevanceModelOfflineScoringPart2Config](
+    groupName = "audience",
+    jobName = "TdidSeedScoreScale") {
+
+  override val prometheus: Option[PrometheusClient] = None
+
+  override def runETLPipeline(): Unit = {
+    val conf = getConfig
+    new TdidSeedScoreScale().run(conf)
   }
 }

--- a/audience/src/main/scala/com/thetradedesk/audience/jobs/UploadEmbeddings.scala
+++ b/audience/src/main/scala/com/thetradedesk/audience/jobs/UploadEmbeddings.scala
@@ -6,17 +6,8 @@ import com.thetradedesk.spark.TTDSparkContext.spark
 import com.thetradedesk.spark.TTDSparkContext.spark.implicits._
 import org.apache.spark.sql.types.FloatType
 
-object UploadEmbeddings
-  extends AutoConfigResolvingETLJobBase[RelevanceModelOfflineScoringPart2Config](
-    groupName = "audience",
-    jobName   = "UploadEmbeddings") {
-
-  override val prometheus = None
-// destination setup from hpc team.  https://gitlab.adsrvr.org/thetradedesk/adplatform/-/merge_requests/83817
-  // and https://thetradedesk.atlassian.net/wiki/x/_OQlAQ
-
-  override def runETLPipeline(): Unit = {
-    val conf = getConfig
+class UploadEmbeddings {
+  def run(conf: RelevanceModelOfflineScoringPart2Config): Unit = {
     val dateStr = date.format(dateFormatter)
     val emb_bucket_dest = conf.emb_bucket_dest
     val tdid_emb_path = conf.tdid_emb_path
@@ -51,5 +42,20 @@ object UploadEmbeddings
       .repartition(totalPartitions)
       .write.format("parquet").mode("overwrite")
       .save(emb_bucket_dest + "type=" + sensitive_emb_enum + "/date=" + dateStr + "/hour=" + "%02d".format(base_hour) + "/batch=" + "%02d".format(batch_id));
+  }
+}
+
+object UploadEmbeddings
+  extends AutoConfigResolvingETLJobBase[RelevanceModelOfflineScoringPart2Config](
+    groupName = "audience",
+    jobName   = "UploadEmbeddings") {
+
+  override val prometheus = None
+// destination setup from hpc team.  https://gitlab.adsrvr.org/thetradedesk/adplatform/-/merge_requests/83817
+  // and https://thetradedesk.atlassian.net/wiki/x/_OQlAQ
+
+  override def runETLPipeline(): Unit = {
+    val conf = getConfig
+    new UploadEmbeddings().run(conf)
   }
 }


### PR DESCRIPTION
## Summary
- convert multiple ETL job objects in audience module into classes and companion objects
- delegate execution to instantiated classes to avoid serialization issues

## Testing
- `sbt -DsparkVersion=3.2.1 test` *(fails: ResolveException when downloading `eldorado-core_2.12`)*

------
https://chatgpt.com/codex/tasks/task_e_687e4c48c8dc8326bc7e97e3981ec05b