### PR TITLE
Fix sampler interface

### DIFF
--- a/audience/src/main/scala/com/thetradedesk/audience/jobs/RelevanceOnlineBiddingDataGeneratorJob.scala
+++ b/audience/src/main/scala/com/thetradedesk/audience/jobs/RelevanceOnlineBiddingDataGeneratorJob.scala
@@ -44,7 +44,7 @@ class RelevanceOnlineBiddingDataGenerator(prometheus: PrometheusClient) {
 
   val jobRunningTime = prometheus.createGauge(s"relevance_online_bidding_generation_job_running_time", "RelevanceOnlineBiddingDataGenerator running time", "date")
   val onlineRelevanceBiddingTableSize = prometheus.createGauge(s"online_relevance_bidding_table_size", "OnlineRelevanceBiddingTableGenerator table size", "date")
-  val sampler = SamplerFactory.fromString("RSMV2Measurement")
+  val sampler = SamplerFactory.fromString("RSMV2Measurement", RelevanceModelInputGeneratorJob.jobConfig)
 
   def generate(date: LocalDate): Unit = {
     // todo
@@ -56,7 +56,7 @@ class RelevanceOnlineBiddingDataGenerator(prometheus: PrometheusClient) {
 
     val aggSeed = AggregatedSeedReadableDataset()
       .readPartition(date)(spark)
-      .filter(sampler.samplingFunction('TDID, RelevanceModelInputGeneratorJob.jobConfig))
+      .filter(sampler.samplingFunction('TDID))
       .cache()
       .repartition(AudienceModelInputGeneratorConfig.bidImpressionRepartitionNumAfterFilter, 'TDID)
 

--- a/audience/src/main/scala/com/thetradedesk/audience/jobs/modelinput/rsmv2/BidImpSideDataGenerator.scala
+++ b/audience/src/main/scala/com/thetradedesk/audience/jobs/modelinput/rsmv2/BidImpSideDataGenerator.scala
@@ -15,11 +15,11 @@ import org.apache.spark.sql.types._
 object BidImpSideDataGenerator {
 
   def readBidImpressionWithNecessary(conf: RelevanceModelInputGeneratorJobConfig): Dataset[BidSideDataRecord] = {
-    val sampler = SamplerFactory.fromString(conf.samplerName)
+    val sampler = SamplerFactory.fromString(conf.samplerName, conf)
     val bidImpressionsS3Path = BidsImpressions.BIDSIMPRESSIONSS3 + "prod/bidsimpressions/"
 
     val bidsImpressionsLongRaw = loadParquetData[BidsImpressionsSchema](bidImpressionsS3Path, date, lookBack = Some(0), source = Some(GERONIMO_DATA_SOURCE))
-      .filter(filterOnIdTypesSym(sampler.samplingFunction('TDID, conf)))
+      .filter(filterOnIdTypesSym(sampler.samplingFunction))
       .withColumn("TDID", getUiid('UIID, 'UnifiedId2, 'EUID, 'IdentityLinkId, 'IdType))
       .select(
           "TDID",

--- a/audience/src/main/scala/com/thetradedesk/audience/jobs/modelinput/rsmv2/usersampling/RSMV2MeasurementSampler.scala
+++ b/audience/src/main/scala/com/thetradedesk/audience/jobs/modelinput/rsmv2/usersampling/RSMV2MeasurementSampler.scala
@@ -6,9 +6,9 @@ import com.thetradedesk.spark.TTDSparkContext.spark.implicits._
 import org.apache.spark.sql.Column
 import org.apache.spark.sql.functions._
 
-object RSMV2MeasurementSampler extends Sampler {
+case class RSMV2MeasurementSampler(conf: RelevanceModelInputGeneratorJobConfig) extends Sampler {
 
-  override def samplingFunction(symbol: Symbol, conf: RelevanceModelInputGeneratorJobConfig): Column = {
+  override def samplingFunction(symbol: Symbol): Column = {
     val hashedValue = abs(xxhash64(concat(symbol, lit(conf.RSMV2UserSampleSalt)))) % lit(10)
 
     shouldTrackTDID(symbol) &&

--- a/audience/src/main/scala/com/thetradedesk/audience/jobs/modelinput/rsmv2/usersampling/RSMV2PopulationSampler.scala
+++ b/audience/src/main/scala/com/thetradedesk/audience/jobs/modelinput/rsmv2/usersampling/RSMV2PopulationSampler.scala
@@ -6,9 +6,9 @@ import com.thetradedesk.spark.TTDSparkContext.spark.implicits._
 import org.apache.spark.sql.Column
 import org.apache.spark.sql.functions._
 
-object RSMV2PopulationSampler extends Sampler {
+case class RSMV2PopulationSampler(conf: RelevanceModelInputGeneratorJobConfig) extends Sampler {
 
-  override def samplingFunction(symbol: Symbol, conf: RelevanceModelInputGeneratorJobConfig): Column = {
+  override def samplingFunction(symbol: Symbol): Column = {
     val hashedValue = abs(xxhash64(concat(symbol, lit(conf.RSMV2UserSampleSalt)))) % lit(10)
 
     shouldTrackTDID(symbol) &&

--- a/audience/src/main/scala/com/thetradedesk/audience/jobs/modelinput/rsmv2/usersampling/RSMV2Sampler.scala
+++ b/audience/src/main/scala/com/thetradedesk/audience/jobs/modelinput/rsmv2/usersampling/RSMV2Sampler.scala
@@ -6,12 +6,13 @@ import com.thetradedesk.spark.TTDSparkContext.spark.implicits._
 import org.apache.spark.sql.Column
 import org.apache.spark.sql.functions._
 
-object RSMV2Sampler extends Sampler {
+case class RSMV2Sampler(conf: RelevanceModelInputGeneratorJobConfig) extends Sampler {
 
-  override def samplingFunction(symbol: Symbol, conf: RelevanceModelInputGeneratorJobConfig): Column = {
+  override def samplingFunction(symbol: Symbol): Column = {
     shouldTrackTDID(symbol) &&
       substring(symbol, 9, 1) === lit("-") &&
-      (abs(xxhash64(concat(symbol, lit(conf.RSMV2UserSampleSalt)))) % lit(10) < lit(conf.RSMV2UserSampleRatio))
+      (abs(xxhash64(concat(symbol, lit(conf.RSMV2UserSampleSalt)))) % lit(10) <
+        lit(conf.RSMV2UserSampleRatio))
   }
 
 }

--- a/audience/src/main/scala/com/thetradedesk/audience/jobs/modelinput/rsmv2/usersampling/SIBSampler.scala
+++ b/audience/src/main/scala/com/thetradedesk/audience/jobs/modelinput/rsmv2/usersampling/SIBSampler.scala
@@ -4,7 +4,6 @@ import com.thetradedesk.spark.TTDSparkContext.spark.implicits._
 import org.apache.spark.sql.Column
 import org.apache.spark.sql.expressions.UserDefinedFunction
 import org.apache.spark.sql.functions._
-import com.thetradedesk.audience.jobs.modelinput.rsmv2.RelevanceModelInputGeneratorJobConfig
 
 import java.util.UUID
 
@@ -146,7 +145,7 @@ object SIBSampler extends Sampler {
   val isDeviceIdSampled = udf(_isDeviceIdSampled _)
   val isDeviceIdSampled1Percent = udf(_isDeviceIdSampled1Percent _)
 
-  override def samplingFunction(symbol: Symbol, conf: RelevanceModelInputGeneratorJobConfig): Column = {
+  override def samplingFunction(symbol: Symbol): Column = {
     isDeviceIdSampled(symbol)
   }
 

--- a/audience/src/main/scala/com/thetradedesk/audience/jobs/modelinput/rsmv2/usersampling/Sampler.scala
+++ b/audience/src/main/scala/com/thetradedesk/audience/jobs/modelinput/rsmv2/usersampling/Sampler.scala
@@ -2,8 +2,7 @@ package com.thetradedesk.audience.jobs.modelinput.rsmv2.usersampling
 
 import org.apache.spark.sql.Column
 import org.apache.spark.sql.functions._
-import com.thetradedesk.audience.jobs.modelinput.rsmv2.RelevanceModelInputGeneratorJobConfig
 
 trait Sampler {
-  def samplingFunction(symbol: Symbol, conf: RelevanceModelInputGeneratorJobConfig): Column
+  def samplingFunction(symbol: Symbol): Column
 }

--- a/audience/src/main/scala/com/thetradedesk/audience/jobs/modelinput/rsmv2/usersampling/SamplerFactory.scala
+++ b/audience/src/main/scala/com/thetradedesk/audience/jobs/modelinput/rsmv2/usersampling/SamplerFactory.scala
@@ -1,12 +1,14 @@
 package com.thetradedesk.audience.jobs.modelinput.rsmv2.usersampling
 
+import com.thetradedesk.audience.jobs.modelinput.rsmv2.RelevanceModelInputGeneratorJobConfig
+
 object SamplerFactory {
-  def fromString(name: String): Sampler = {
+  def fromString(name: String, conf: RelevanceModelInputGeneratorJobConfig): Sampler = {
     name match {
       case "SIB" => SIBSampler
-      case "RSMV2" => RSMV2Sampler
-      case "RSMV2Measurement" => RSMV2MeasurementSampler // will help measurement job use split=1 in feature_store to speed up the process
-      case "RSMV2Population" => RSMV2PopulationSampler // will help measurement job use split=1 in feature_store to speed up the process
+      case "RSMV2" => RSMV2Sampler(conf)
+      case "RSMV2Measurement" => RSMV2MeasurementSampler(conf) // will help measurement job use split=1 in feature_store to speed up the process
+      case "RSMV2Population" => RSMV2PopulationSampler(conf) // will help measurement job use split=1 in feature_store to speed up the process
       case _ => throw new IllegalArgumentException(s"Unknown sampler: $name")
     }
   }


### PR DESCRIPTION
## Summary
- refactor sampler interface to drop explicit config argument
- update samplers to case classes that hold configuration
- patch usage to match new interface in RelevanceOnlineBiddingDataGeneratorJob
- patch BidImpSideDataGenerator and utilities

## Testing
- `sbt test:compile` *(failed: Error downloading dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6883184c5ba883268bfa293929576e6b