### PR TITLE
Add retry handling for S3 ops and pluggable logger factory

### DIFF
--- a/confetti/src/main/scala/com/thetradedesk/confetti/AutoConfigResolvingETLJobBase.scala
+++ b/confetti/src/main/scala/com/thetradedesk/confetti/AutoConfigResolvingETLJobBase.scala
@@ -1,6 +1,6 @@
 package com.thetradedesk.confetti
 
-import com.thetradedesk.confetti.utils.{CloudWatchLogger, CloudWatchLoggerFactory, MapConfigReader, S3Utils}
+import com.thetradedesk.confetti.utils.{CloudWatchLoggerFactory, Logger, LoggerFactory, MapConfigReader, S3Utils}
 import com.thetradedesk.spark.util.TTDConfig.config
 import org.yaml.snakeyaml.Yaml
 import com.thetradedesk.spark.util.prometheus.PrometheusClient
@@ -14,7 +14,11 @@ import scala.reflect.runtime.universe._
  * before running the user defined ETL pipeline and writes its result to S3.
  */
 
-abstract class AutoConfigResolvingETLJobBase[C: TypeTag : ClassTag](groupName: String, jobName: String) extends Serializable {
+abstract class AutoConfigResolvingETLJobBase[C: TypeTag : ClassTag](
+    groupName: String,
+    jobName: String,
+    loggerFactory: LoggerFactory = CloudWatchLoggerFactory
+  ) extends Serializable {
   @transient lazy val confettiEnv = config.getStringRequired("confettiEnv")
   @transient lazy val experimentName = config.getStringOption("experimentName")
   @transient lazy val runtimeConfigBasePath = config.getStringRequired("confettiRuntimeConfigBasePath")
@@ -22,7 +26,7 @@ abstract class AutoConfigResolvingETLJobBase[C: TypeTag : ClassTag](groupName: S
   /** Optional Prometheus client for pushing metrics. */
   protected val prometheus: Option[PrometheusClient]
 
-  @transient lazy val logger = CloudWatchLoggerFactory.getLogger(
+  @transient lazy val logger: Logger = loggerFactory.getLogger(
     s"Confetti-$confettiEnv",
     s"${experimentName.filter(_.nonEmpty).map(n => s"$n-").getOrElse("")}$groupName-$jobName"
   )
@@ -35,7 +39,7 @@ abstract class AutoConfigResolvingETLJobBase[C: TypeTag : ClassTag](groupName: S
   protected final def getConfig: C =
     jobConfig.getOrElse(throw new IllegalStateException("Config not initialized"))
 
-  protected final def getLogger: CloudWatchLogger = logger
+  protected final def getLogger: Logger = logger
 
   /** Entry point for jobs extending this base. Executes the pipeline and pushes metrics. */
   final def main(args: Array[String]): Unit = {
@@ -54,7 +58,9 @@ abstract class AutoConfigResolvingETLJobBase[C: TypeTag : ClassTag](groupName: S
     if (runtimeConfigBasePath.endsWith("/")) runtimeConfigBasePath else runtimeConfigBasePath + "/"
 
   private final def execute(): Unit = {
-    val yamlPaths = S3Utils.listYamlFiles(runtimePathBase)
+    val yamlPaths = withRetry("list YAML files from S3") {
+      S3Utils.listYamlFiles(runtimePathBase)
+    }
     val config = yamlPaths
       .map(readYaml)
       .foldLeft(Map.empty[String, String])(_ ++ _)
@@ -65,12 +71,16 @@ abstract class AutoConfigResolvingETLJobBase[C: TypeTag : ClassTag](groupName: S
     }
     runETLPipeline()
     // Write a _SUCCESS file to signal job completion with experiment name
-    S3Utils.writeToS3(runtimePathBase + "_SUCCESS", experimentName.getOrElse(""))
+    withRetry("write success marker to S3") {
+      S3Utils.writeToS3(runtimePathBase + "_SUCCESS", experimentName.getOrElse(""))
+    }
   }
 
   /** Read a YAML file from S3 into a map. */
   private def readYaml(path: String): Map[String, String] = {
-    val yamlStr = S3Utils.readFromS3(path)
+    val yamlStr = withRetry(s"read YAML from $path") {
+      S3Utils.readFromS3(path)
+    }
     val yaml = new Yaml()
     val javaMap = yaml.load[java.util.Map[String, Any]](yamlStr)
     javaMap.asScala.map { case (k, v) => k -> v.toString }.toMap
@@ -80,7 +90,30 @@ abstract class AutoConfigResolvingETLJobBase[C: TypeTag : ClassTag](groupName: S
   private def writeYaml(config: Map[String, String], s3Path: String): Unit = {
     val yaml = new Yaml()
     val rendered = yaml.dump(config.asJava)
-    S3Utils.writeToS3(s3Path, rendered)
+    withRetry(s"write YAML to $s3Path") {
+      S3Utils.writeToS3(s3Path, rendered)
+    }
+  }
+
+  /** Retry the given block up to 5 times with simple backoff and final error logging. */
+  private def withRetry[T](operation: String, retries: Int = 5)(block: => T): T = {
+    var attempt = 0
+    var lastError: Throwable = null
+    while (attempt < retries) {
+      try {
+        return block
+      } catch {
+        case e: Throwable =>
+          lastError = e
+          attempt += 1
+          logger.warn(s"$operation failed on attempt $attempt: ${e.getMessage}")
+          if (attempt < retries) {
+            Thread.sleep(1000L * attempt)
+          }
+      }
+    }
+    logger.error(s"$operation failed after $retries attempts: ${lastError.getMessage}")
+    throw lastError
   }
 
 }

--- a/confetti/src/main/scala/com/thetradedesk/confetti/utils/CloudWatchLogger.scala
+++ b/confetti/src/main/scala/com/thetradedesk/confetti/utils/CloudWatchLogger.scala
@@ -11,7 +11,7 @@ import scala.collection.JavaConverters._
  * @param logGroup  name of the CloudWatch log group
  * @param logStream name of the CloudWatch log stream
  */
-class CloudWatchLogger(client: AWSLogs, logGroup: String, logStream: String) {
+class CloudWatchLogger(client: AWSLogs, logGroup: String, logStream: String) extends Logger {
   // Cache the next sequence token so we don't have to fetch it from CloudWatch
   // for every log entry. It is refreshed after each putLogEvents call.
   private var sequenceToken: Option[String] = fetchSequenceToken()
@@ -22,13 +22,13 @@ class CloudWatchLogger(client: AWSLogs, logGroup: String, logStream: String) {
     streams.headOption.flatMap(s => Option(s.getUploadSequenceToken))
   }
 
-  def debug(message: String): Unit = log("DEBUG", message)
+  override def debug(message: String): Unit = log("DEBUG", message)
 
-  def info(message: String): Unit = log("INFO", message)
+  override def info(message: String): Unit = log("INFO", message)
 
-  def warn(message: String): Unit = log("WARN", message)
+  override def warn(message: String): Unit = log("WARN", message)
 
-  def error(message: String): Unit = log("ERROR", message)
+  override def error(message: String): Unit = log("ERROR", message)
 
   def log(level: String, message: String): Unit = {
     val event = new InputLogEvent()

--- a/confetti/src/main/scala/com/thetradedesk/confetti/utils/CloudWatchLoggerFactory.scala
+++ b/confetti/src/main/scala/com/thetradedesk/confetti/utils/CloudWatchLoggerFactory.scala
@@ -12,12 +12,12 @@ import scala.collection.JavaConverters._
  * The factory ensures the log group and stream exist before
  * returning the logger.
  */
-object CloudWatchLoggerFactory {
+object CloudWatchLoggerFactory extends LoggerFactory {
   /**
    * Obtain a CloudWatchLogger for the provided log group and stream.
    * A new logger instance is created on every call.
    */
-  def getLogger(logGroup: String, logStream: String): CloudWatchLogger = {
+  override def getLogger(logGroup: String, logStream: String): Logger = {
     val client = AWSLogsClientBuilder.standard()
       .withRegion(Regions.US_EAST_1)
       .build()

--- a/confetti/src/main/scala/com/thetradedesk/confetti/utils/Logger.scala
+++ b/confetti/src/main/scala/com/thetradedesk/confetti/utils/Logger.scala
@@ -1,0 +1,14 @@
+package com.thetradedesk.confetti.utils
+
+/** Simple logging interface allowing different implementations. */
+trait Logger {
+  def debug(message: String): Unit
+  def info(message: String): Unit
+  def warn(message: String): Unit
+  def error(message: String): Unit
+}
+
+/** Factory for creating loggers. */
+trait LoggerFactory {
+  def getLogger(logGroup: String, logStream: String): Logger
+}

--- a/confetti/src/main/scala/com/thetradedesk/confetti/utils/MapConfigReader.scala
+++ b/confetti/src/main/scala/com/thetradedesk/confetti/utils/MapConfigReader.scala
@@ -11,7 +11,7 @@ import scala.util.Try
  * report all issues at once. Fields typed as `Option[T]` are treated
  * as optional; other fields are required.
  */
-class MapConfigReader(map: Map[String, String], logger: CloudWatchLogger) {
+class MapConfigReader(map: Map[String, String], logger: Logger) {
   private val errors = ListBuffer.empty[String]
 
   private def getSeqOpt[T](


### PR DESCRIPTION
## Summary
- Add configurable logger factory with default CloudWatch implementation
- Introduce generic logger interface and update utilities
- Retry and log failures for S3 read, write, and list operations

## Testing
- `sbt -no-colors test` *(fails: ResolveException: Error downloading com.thetradedesk:eldorado-core_2.12:1.0.285-spark-3.2.1)*

------
https://chatgpt.com/codex/tasks/task_e_6891937878d88326af3356a70c5a1c3e