### PR TITLE
Avoid capturing job instance in dot product generator

### DIFF
--- a/audience/src/main/scala/com/thetradedesk/audience/jobs/TdidEmbeddingDotProductGeneratorOOS.scala
+++ b/audience/src/main/scala/com/thetradedesk/audience/jobs/TdidEmbeddingDotProductGeneratorOOS.scala
@@ -20,18 +20,6 @@ import java.security.MessageDigest
 
 class TdidEmbeddingDotProductGeneratorOOS {
 
-  val EmbeddingSize = 64
-
-  val sigmoid = (x: Float) => (1.0f / (1.0f + math.exp(-x))).toFloat
-
-  val embeddings2scores = (bdEmb: Seq[Float], seedEmb: Seq[Float], index: Int) => {
-    var sum = 0f
-    for (i <- 0 until EmbeddingSize) {
-      sum = sum + bdEmb(i) * seedEmb(i + index)
-    }
-    sigmoid(sum)
-  }
-
   case class SeedScore(SeedId:String, Score:Float)
 
   def convertUID2ToGUID(uid2: String) = {
@@ -71,6 +59,18 @@ class TdidEmbeddingDotProductGeneratorOOS {
     val minMaxSeedEmb = conf.minMaxSeedEmb
     val r = conf.r.toFloat
     val loc_factor = conf.loc_factor.toFloat
+
+    val embeddingSize = 64
+    val sigmoid = (x: Float) => (1.0f / (1.0f + math.exp(-x))).toFloat
+    val embeddings2scores = (bdEmb: Seq[Float], seedEmb: Seq[Float], index: Int) => {
+      var sum = 0f
+      var i = 0
+      while (i < embeddingSize) {
+        sum += bdEmb(i) * seedEmb(i + index)
+        i += 1
+      }
+      sigmoid(sum)
+    }
 
     val df_seed_emb = spark.read.format("parquet").load(seed_emb_path)
       .withColumn("maxEmbedding", array_max('Embedding))
@@ -123,11 +123,11 @@ class TdidEmbeddingDotProductGeneratorOOS {
     val relevanceScoreUDF = udf(
       (bdSenEmb: Array[Float], bdNonSenEmb: Array[Float], SyntheticIdsLevel1: Array[Int], SyntheticIdsLevel2: Array[Int], SeedSyntheticIdsLevel1: Array[Int], SeedSyntheticIdsLevel2: Array[Int]) => {
         val syntheticIdToLevel = mutable.HashMap[Int, Int]()
-        if (SyntheticIdsLevel2.nonEmpty) SyntheticIdsLevel2.foreach(e => syntheticIdToLevel.put(e, 2 * EmbeddingSize))
-        if (SeedSyntheticIdsLevel2.nonEmpty) SeedSyntheticIdsLevel2.foreach(e => syntheticIdToLevel.put(e, 2 * EmbeddingSize))
+        if (SyntheticIdsLevel2.nonEmpty) SyntheticIdsLevel2.foreach(e => syntheticIdToLevel.put(e, 2 * embeddingSize))
+        if (SeedSyntheticIdsLevel2.nonEmpty) SeedSyntheticIdsLevel2.foreach(e => syntheticIdToLevel.put(e, 2 * embeddingSize))
 
-        if (SyntheticIdsLevel1.nonEmpty) SyntheticIdsLevel1.foreach(e => if (!syntheticIdToLevel.contains(e)) syntheticIdToLevel.put(e, 1 * EmbeddingSize))
-        if (SeedSyntheticIdsLevel1.nonEmpty) SeedSyntheticIdsLevel1.foreach(e => if (!syntheticIdToLevel.contains(e)) syntheticIdToLevel.put(e, 1 * EmbeddingSize))
+        if (SyntheticIdsLevel1.nonEmpty) SyntheticIdsLevel1.foreach(e => if (!syntheticIdToLevel.contains(e)) syntheticIdToLevel.put(e, 1 * embeddingSize))
+        if (SeedSyntheticIdsLevel1.nonEmpty) SeedSyntheticIdsLevel1.foreach(e => if (!syntheticIdToLevel.contains(e)) syntheticIdToLevel.put(e, 1 * embeddingSize))
         df_seed_emb_sensitivity
           .value
           .map(
@@ -136,17 +136,17 @@ class TdidEmbeddingDotProductGeneratorOOS {
               if (sensitiveModel) {
                 // skip embedding 0, only use embedding 1-3
                 val pair = if (e._3)
-                  (embeddings2scores(bdSenEmb, e._2, offset), offset / EmbeddingSize) // sensitive advertiser
+                  (embeddings2scores(bdSenEmb, e._2, offset), offset / embeddingSize) // sensitive advertiser
                 else
-                  (embeddings2scores(bdNonSenEmb, e._2, offset), offset / EmbeddingSize) // pair._2 is the density level
+                  (embeddings2scores(bdNonSenEmb, e._2, offset), offset / embeddingSize) // pair._2 is the density level
 
                 pair._1
               } else {
                 // non sensitive model, for sensitive advertiser, always use embedding 0
                 val pair = if (e._3)
-                  (embeddings2scores(bdSenEmb, e._2, 0), offset / EmbeddingSize) // sensitive advertiser, always 0 embedding
+                  (embeddings2scores(bdSenEmb, e._2, 0), offset / embeddingSize) // sensitive advertiser, always 0 embedding
                 else
-                  (embeddings2scores(bdNonSenEmb, e._2, offset + EmbeddingSize), offset / EmbeddingSize) // note: offset is 2 for level2, the corresponding offset should add another EmbeddingSize
+                  (embeddings2scores(bdNonSenEmb, e._2, offset + embeddingSize), offset / embeddingSize) // note: offset is 2 for level2, the corresponding offset should add another embeddingSize
 
                 pair._1
               }


### PR DESCRIPTION
## Summary
- avoid capturing `TdidEmbeddingDotProductGeneratorOOS` instance inside UDF by defining embedding helpers within `run`
- update relevance scoring UDF to use local `embeddingSize` constant

## Testing
- `sbt test` *(fails: Error downloading com.thetradedesk:eldorado-core_2.12:1.0.285-spark-3.2.1)*

------
https://chatgpt.com/codex/tasks/task_e_689422dba04c832688da16ecb3640598