### PR TITLE
Allow SamplerFactory to work with generic configs

### DIFF
--- a/audience/src/main/scala/com/thetradedesk/audience/jobs/modelinput/rsmv2/usersampling/RSMV2MeasurementSampler.scala
+++ b/audience/src/main/scala/com/thetradedesk/audience/jobs/modelinput/rsmv2/usersampling/RSMV2MeasurementSampler.scala
@@ -1,19 +1,33 @@
 package com.thetradedesk.audience.jobs.modelinput.rsmv2.usersampling
 
-import com.thetradedesk.audience.jobs.modelinput.rsmv2.RelevanceModelInputGeneratorJobConfig
 import com.thetradedesk.audience.shouldTrackTDID
 import com.thetradedesk.spark.TTDSparkContext.spark.implicits._
 import org.apache.spark.sql.Column
 import org.apache.spark.sql.functions._
+import SamplerConfigUtils._
 
-case class RSMV2MeasurementSampler(conf: RelevanceModelInputGeneratorJobConfig) extends Sampler {
+/** Sampler used for measurement jobs. It selects one specific 1/10th bucket
+  * determined by a hash of the TDID.
+  */
+case class RSMV2MeasurementSampler(conf: Any) extends Sampler {
+
+  private val sampleSalt: String =
+    getString(conf, "sampleSalt")
+      .orElse(getString(conf, "RSMV2UserSampleSalt"))
+      .getOrElse(throw new IllegalArgumentException("sampleSalt is required"))
+
+  private val sampleRatio: Int =
+    getInt(conf, "sampleRatio")
+      .orElse(getInt(conf, "RSMV2UserSampleRatio"))
+      .getOrElse(throw new IllegalArgumentException("sampleRatio is required"))
 
   override def samplingFunction(symbol: Symbol): Column = {
-    val hashedValue = abs(xxhash64(concat(symbol, lit(conf.RSMV2UserSampleSalt)))) % lit(10)
+    val hashedValue = abs(xxhash64(concat(symbol, lit(sampleSalt)))) % lit(10)
 
     shouldTrackTDID(symbol) &&
       substring(symbol, 9, 1) === lit("-") &&
-      (hashedValue >= lit(conf.RSMV2UserSampleRatio)) &&
-      (hashedValue < (lit(conf.RSMV2UserSampleRatio) + lit(1)))
+      (hashedValue >= lit(sampleRatio)) &&
+      (hashedValue < (lit(sampleRatio) + lit(1)))
   }
 }
+

--- a/audience/src/main/scala/com/thetradedesk/audience/jobs/modelinput/rsmv2/usersampling/RSMV2PopulationSampler.scala
+++ b/audience/src/main/scala/com/thetradedesk/audience/jobs/modelinput/rsmv2/usersampling/RSMV2PopulationSampler.scala
@@ -1,18 +1,33 @@
 package com.thetradedesk.audience.jobs.modelinput.rsmv2.usersampling
 
-import com.thetradedesk.audience.jobs.modelinput.rsmv2.RelevanceModelInputGeneratorJobConfig
 import com.thetradedesk.audience.shouldTrackTDID
 import com.thetradedesk.spark.TTDSparkContext.spark.implicits._
 import org.apache.spark.sql.Column
 import org.apache.spark.sql.functions._
+import SamplerConfigUtils._
 
-case class RSMV2PopulationSampler(conf: RelevanceModelInputGeneratorJobConfig) extends Sampler {
+/** Sampler used for generating population statistics. Configuration requires
+  * a `sampleSalt` and a sequence of `sampleIndexes` indicating which hashed
+  * buckets should be kept.
+  */
+case class RSMV2PopulationSampler(conf: Any) extends Sampler {
+
+  private val sampleSalt: String =
+    getString(conf, "sampleSalt")
+      .orElse(getString(conf, "RSMV2UserSampleSalt"))
+      .getOrElse(throw new IllegalArgumentException("sampleSalt is required"))
+
+  private val sampleIndexes: Seq[Int] =
+    getSeqInt(conf, "sampleIndexes")
+      .orElse(getSeqInt(conf, "RSMV2PopulationUserSampleIndex"))
+      .getOrElse(throw new IllegalArgumentException("sampleIndexes are required"))
 
   override def samplingFunction(symbol: Symbol): Column = {
-    val hashedValue = abs(xxhash64(concat(symbol, lit(conf.RSMV2UserSampleSalt)))) % lit(10)
+    val hashedValue = abs(xxhash64(concat(symbol, lit(sampleSalt)))) % lit(10)
 
     shouldTrackTDID(symbol) &&
       substring(symbol, 9, 1) === lit("-") &&
-      (hashedValue.isin(conf.RSMV2PopulationUserSampleIndex: _*))
+      (hashedValue.isin(sampleIndexes: _*))
   }
 }
+

--- a/audience/src/main/scala/com/thetradedesk/audience/jobs/modelinput/rsmv2/usersampling/RSMV2Sampler.scala
+++ b/audience/src/main/scala/com/thetradedesk/audience/jobs/modelinput/rsmv2/usersampling/RSMV2Sampler.scala
@@ -1,18 +1,33 @@
 package com.thetradedesk.audience.jobs.modelinput.rsmv2.usersampling
 
-import com.thetradedesk.audience.jobs.modelinput.rsmv2.RelevanceModelInputGeneratorJobConfig
 import com.thetradedesk.audience.shouldTrackTDID
 import com.thetradedesk.spark.TTDSparkContext.spark.implicits._
 import org.apache.spark.sql.Column
 import org.apache.spark.sql.functions._
+import SamplerConfigUtils._
 
-case class RSMV2Sampler(conf: RelevanceModelInputGeneratorJobConfig) extends Sampler {
+/** Sampler used for general RSMV2 jobs. The configuration can be any object
+  * that exposes `sampleSalt` and `sampleRatio` fields (or their historical
+  * counterparts `RSMV2UserSampleSalt` and `RSMV2UserSampleRatio`).
+  */
+case class RSMV2Sampler(conf: Any) extends Sampler {
+
+  private val sampleSalt: String =
+    getString(conf, "sampleSalt")
+      .orElse(getString(conf, "RSMV2UserSampleSalt"))
+      .getOrElse(throw new IllegalArgumentException("sampleSalt is required"))
+
+  private val sampleRatio: Int =
+    getInt(conf, "sampleRatio")
+      .orElse(getInt(conf, "RSMV2UserSampleRatio"))
+      .getOrElse(throw new IllegalArgumentException("sampleRatio is required"))
 
   override def samplingFunction(symbol: Symbol): Column = {
     shouldTrackTDID(symbol) &&
       substring(symbol, 9, 1) === lit("-") &&
-      (abs(xxhash64(concat(symbol, lit(conf.RSMV2UserSampleSalt)))) % lit(10) <
-        lit(conf.RSMV2UserSampleRatio))
+      (abs(xxhash64(concat(symbol, lit(sampleSalt)))) % lit(10) <
+        lit(sampleRatio))
   }
 
 }
+

--- a/audience/src/main/scala/com/thetradedesk/audience/jobs/modelinput/rsmv2/usersampling/SamplerConfigUtils.scala
+++ b/audience/src/main/scala/com/thetradedesk/audience/jobs/modelinput/rsmv2/usersampling/SamplerConfigUtils.scala
@@ -1,0 +1,51 @@
+package com.thetradedesk.audience.jobs.modelinput.rsmv2.usersampling
+
+/** Utility helpers for extracting strongly typed values from a configuration
+  * object whose concrete type is unknown at compile time. The configuration may
+  * either be a case class with accessor methods or a `Map[String, Any]`.
+  */
+private[usersampling] object SamplerConfigUtils {
+
+  /** Attempt to read a String field from the configuration. */
+  def getString(conf: Any, field: String): Option[String] = conf match {
+    case m: Map[_, _] =>
+      m.asInstanceOf[Map[String, Any]].get(field).collect { case s: String => s }
+    case _ =>
+      try {
+        Option(conf.getClass.getMethod(field).invoke(conf): Any).collect { case s: String => s }
+      } catch {
+        case _: Throwable => None
+      }
+  }
+
+  /** Attempt to read an Int field from the configuration. */
+  def getInt(conf: Any, field: String): Option[Int] = conf match {
+    case m: Map[_, _] =>
+      m.asInstanceOf[Map[String, Any]].get(field).collect { case i: Int => i }
+    case _ =>
+      try {
+        Option(conf.getClass.getMethod(field).invoke(conf): Any).collect { case i: Int => i }
+      } catch {
+        case _: Throwable => None
+      }
+  }
+
+  /** Attempt to read a sequence of Int from the configuration. */
+  def getSeqInt(conf: Any, field: String): Option[Seq[Int]] = conf match {
+    case m: Map[_, _] =>
+      m.asInstanceOf[Map[String, Any]].get(field).map {
+        case seq: Seq[_] => seq.collect { case i: Int => i }
+        case other       => throw new IllegalArgumentException(s"Field '$field' expected Seq[Int] but found ${other.getClass}")
+      }
+    case _ =>
+      try {
+        Option(conf.getClass.getMethod(field).invoke(conf): Any).map {
+          case seq: Seq[_] => seq.collect { case i: Int => i }
+          case other       => throw new IllegalArgumentException(s"Field '$field' expected Seq[Int] but found ${other.getClass}")
+        }
+      } catch {
+        case _: Throwable => None
+      }
+  }
+}
+

--- a/audience/src/main/scala/com/thetradedesk/audience/jobs/modelinput/rsmv2/usersampling/SamplerFactory.scala
+++ b/audience/src/main/scala/com/thetradedesk/audience/jobs/modelinput/rsmv2/usersampling/SamplerFactory.scala
@@ -1,15 +1,28 @@
 package com.thetradedesk.audience.jobs.modelinput.rsmv2.usersampling
 
-import com.thetradedesk.audience.jobs.modelinput.rsmv2.RelevanceModelInputGeneratorJobConfig
-
+/** Factory for building samplers based on name. The configuration type is kept
+  * generic so that individual samplers can decide how to interpret the values
+  * they need.
+  */
 object SamplerFactory {
-  def fromString(name: String, conf: RelevanceModelInputGeneratorJobConfig): Sampler = {
+
+  /**
+    * Create a [[Sampler]] by name using an arbitrary configuration object.
+    *
+    * @param name identifier of the sampler to build
+    * @param conf configuration object understood by the selected sampler
+    * @return the concrete [[Sampler]] implementation
+    */
+  def fromString(name: String, conf: Any): Sampler = {
     name match {
       case "SIB" => SIBSampler
       case "RSMV2" => RSMV2Sampler(conf)
-      case "RSMV2Measurement" => RSMV2MeasurementSampler(conf) // will help measurement job use split=1 in feature_store to speed up the process
-      case "RSMV2Population" => RSMV2PopulationSampler(conf) // will help measurement job use split=1 in feature_store to speed up the process
+      case "RSMV2Measurement" =>
+        RSMV2MeasurementSampler(conf) // used by measurement job to speed up process
+      case "RSMV2Population" =>
+        RSMV2PopulationSampler(conf) // used by measurement job to speed up process
       case _ => throw new IllegalArgumentException(s"Unknown sampler: $name")
     }
   }
 }
+


### PR DESCRIPTION
## Summary
- Let `SamplerFactory.fromString` accept any config object
- Extract sampler settings at runtime so samplers only require needed fields
- Add utility helpers for pulling typed values from generic configs
- Cast reflection results to `Any` to avoid pattern type mismatches when reading config values

## Testing
- `sbt test` *(fails: command not found)*
- `apt-get install -y openjdk-11-jdk` *(fails: Sub-process /usr/bin/dpkg returned an error code (1))*


------
https://chatgpt.com/codex/tasks/task_e_68a5c0f23c0883269196672669997370