### PR TITLE
Initialize spark session for marker-based early exit

### DIFF
--- a/confetti/src/main/scala/com/thetradedesk/confetti/AutoConfigResolvingETLJobBase.scala
+++ b/confetti/src/main/scala/com/thetradedesk/confetti/AutoConfigResolvingETLJobBase.scala
@@ -4,6 +4,7 @@ import com.thetradedesk.confetti.utils.{CloudWatchLoggerFactory, Logger, LoggerF
 import com.thetradedesk.spark.util.TTDConfig.config
 import org.yaml.snakeyaml.Yaml
 import com.thetradedesk.spark.util.prometheus.PrometheusClient
+import org.apache.spark.sql.SparkSession
 
 import scala.collection.JavaConverters._
 import scala.reflect.ClassTag
@@ -58,6 +59,30 @@ abstract class AutoConfigResolvingETLJobBase[C: TypeTag : ClassTag](
     if (runtimeConfigBasePath.endsWith("/")) runtimeConfigBasePath else runtimeConfigBasePath + "/"
 
   private final def execute(): Unit = {
+    val successPath = runtimePathBase + "_SUCCESS"
+    val runningPath = runtimePathBase + "_RUNNING"
+    if (withRetry("check success marker on S3") {
+          S3Utils.exists(successPath)
+        }) {
+      logger.info(s"Success marker exists at $successPath; skipping execution")
+      val spark = SparkSession.builder().getOrCreate()
+      spark.stop()
+      return
+    }
+    if (withRetry("check running marker on S3") {
+          S3Utils.exists(runningPath)
+        }) {
+      val msg = s"Running marker exists at $runningPath; aborting job"
+      logger.error(msg)
+      val spark = SparkSession.builder().getOrCreate()
+      spark.stop()
+      throw new IllegalStateException(msg)
+    }
+    withRetry("write running marker to S3") {
+      S3Utils.writeToS3(runningPath, experimentName.getOrElse(""))
+    }
+    logger.info(s"Wrote running marker to $runningPath")
+
     val yamlPaths = withRetry("list YAML files from S3") {
       S3Utils.listYamlFiles(runtimePathBase)
     }
@@ -72,8 +97,9 @@ abstract class AutoConfigResolvingETLJobBase[C: TypeTag : ClassTag](
     runETLPipeline()
     // Write a _SUCCESS file to signal job completion with experiment name
     withRetry("write success marker to S3") {
-      S3Utils.writeToS3(runtimePathBase + "_SUCCESS", experimentName.getOrElse(""))
+      S3Utils.writeToS3(successPath, experimentName.getOrElse(""))
     }
+    logger.info(s"Wrote success marker to $successPath")
   }
 
   /** Read a YAML file from S3 into a map. */

--- a/confetti/src/main/scala/com/thetradedesk/confetti/utils/S3Utils.scala
+++ b/confetti/src/main/scala/com/thetradedesk/confetti/utils/S3Utils.scala
@@ -25,6 +25,12 @@ object S3Utils {
     s3Client.putObject(uri.getBucket, uri.getKey, is, null)
   }
 
+  /** Check if an object exists at the given S3 path. */
+  def exists(path: String): Boolean = {
+    val uri = new AmazonS3URI(path)
+    s3Client.doesObjectExist(uri.getBucket, uri.getKey)
+  }
+
   /** List YAML files under the given S3 folder path. */
   def listYamlFiles(folderPath: String): Seq[String] = {
     val uri = new AmazonS3URI(folderPath)


### PR DESCRIPTION
## Summary
- initialize and stop a Spark session when `_SUCCESS` or `_RUNNING` markers are detected to prevent Yarn from complaining about a missing Spark context

## Testing
- `sbt test` *(fails: command not found)*
- `apt-get install -y sbt` *(unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68b04db292f4832685750936738e3d15