### PR TITLE
Simplify runtime config loading and validation

### DIFF
--- a/confetti/src/main/scala/com/thetradedesk/confetti/AutoConfigResolvingETLJobBase.scala
+++ b/confetti/src/main/scala/com/thetradedesk/confetti/AutoConfigResolvingETLJobBase.scala
@@ -66,7 +66,7 @@ abstract class AutoConfigResolvingETLJobBase[C: TypeTag : ClassTag](
         return
       }
 
-      val config = loader.writeRuntimeConfigs(runtimePathBase, identityCfg, runtimeVars)
+      val config = loader.loadRuntimeConfigs(runtimePathBase, identityCfg, runtimeVars)
 
       val successPath = runtimePathBase + "_SUCCESS"
       val runningPath = runtimePathBase + "_RUNNING"


### PR DESCRIPTION
## Summary
- Stop writing identity config to `runtime_config.yml` and load remaining templates via `loadRuntimeConfigs`
- Validate unresolved variables inside `renderRuntimeVariables` and drop `checkForUnresolvedVariables`
- Update job base to call the new loader method

## Testing
- `sbt test` *(fails: command not found)*
- `apt-get install -y sbt` *(fails: Unable to locate package sbt)*

------
https://chatgpt.com/codex/tasks/task_e_68b87fa64cb88326b382d5dfccdc4380